### PR TITLE
Add cli extension

### DIFF
--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -7,6 +7,11 @@ on:
         description: 'The name of the script to run in package.json '
         type: string
         default: 'build-verify'
+      cli-options:
+        description: 'Options to pass to the build script'
+        required: false
+        type: string
+        default: '-- --extension ./extensions/antora/antora-page-list'
       deploy-id:
         description: 'The Deploy ID or PR number if workflow called by a PR'
         required: true

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -11,7 +11,7 @@ on:
         description: 'Options to pass to the build script'
         required: false
         type: string
-        default: '-- --extension ./extensions/antora/antora-page-list'
+        default: '-- --extension ./.docs-tools/extensions/antora/antora-page-list'
       deploy-id:
         description: 'The Deploy ID or PR number if workflow called by a PR'
         required: true
@@ -78,7 +78,7 @@ jobs:
         ref: dev
         sparse-checkout: |
           extensions/antora
-        path: extensions/antora
+        path: .docs-tools
 
     - name: Use Node.js 16
       uses: actions/setup-node@v3

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -40,7 +40,7 @@ on:
         description: 'Options to pass to the build script'
         required: false
         type: string
-        default: '-- --extension ./extensions/antora/antora-page-list'
+        default: '-- --extension ./.docs-tools/extensions/antora/antora-page-list'
       deploy-id:
         description: 'A deploy ID'
         required: true

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -31,6 +31,11 @@ on:
         required: true
         type: string
         default: 'build-verify'
+      cli-options:
+        description: 'Options to pass to the build script'
+        required: false
+        type: string
+        default: '-- --extension ./extensions/antora/antora-page-list'
       deploy-id:
         description: 'A deploy ID'
         required: true
@@ -56,9 +61,19 @@ jobs:
     env:
       PACKAGE_SCRIPT: ${{ inputs.package-script }}
       DEPLOY_ID: ${{ inputs.deploy-id }}
+      CLI_OPTIONS: ${{ inputs.cli-options }}
 
     steps:    
     - uses: actions/checkout@v3
+
+    - name: Checkout tools repo
+      uses: actions/checkout@v4
+      with:
+        repository: neo4j/docs-tools
+        ref: dev
+        sparse-checkout: |
+          extensions/antora
+        path: extensions/antora
 
     - name: Use Node.js 16
       uses: actions/setup-node@v3
@@ -69,7 +84,7 @@ jobs:
       run: npm install --omit=dev
 
     - name: Run package script
-      run: npm run $PACKAGE_SCRIPT
+      run: npm run $PACKAGE_SCRIPT $CLI_OPTIONS
 
     - name: Save event-id
       run: echo $DEPLOY_ID > ./build/deployid


### PR DESCRIPTION
Merge the updated _reusable-docs-build.yml_ workflow into `main`.

The workflow now checkouts out antora extensions from the docs-tools repo to _./.docs-tools/_ in the repo where the workflow is running. This enables it to use the page-list extension for enhanced automated github PR deploy comments  without the extension having to be installed in every docs repo and added to every docs playbook.