### PR TITLE
Deploy path for docs.zip with any dirname

### DIFF
--- a/.github/workflows/docs-deploy-surge.yml
+++ b/.github/workflows/docs-deploy-surge.yml
@@ -63,6 +63,11 @@ jobs:
       - id: unzip-docs
         run: unzip docs.zip
 
+      - id: get-top-dir
+        run: |
+          root=$(ls -d build/*/index.html | sed -r 's/build\/(.*)\/index\.html/\1/')
+          echo "top-dir=$root" >> $GITHUB_OUTPUT
+
       - id: unzip-changelog
         if: ${{ hashFiles('changelog.zip') != '' }}
         run: unzip changelog.zip
@@ -91,9 +96,10 @@ jobs:
         env:
           DEPLOY_URL: ${{ steps.get-deploy-url.outputs.deploy-url }}
           SURGE_TOKEN: "${{ secrets.DOCS_SURGE_TOKEN }}"
+          SITE_DIR: ${{ steps.get-top-dir.outputs.top-dir }}
         run: |
           npm install -g surge
-          surge ./site $DEPLOY_URL --token "$SURGE_TOKEN"
+          surge ./$SITE_DIR $DEPLOY_URL --token "$SURGE_TOKEN"
 
       # If the PR artifacts include a changelog file, add it to the PR as a comment
       # The changelog contains links to new and changed files in the deployed docs

--- a/.github/workflows/docs-deploy-surge.yml
+++ b/.github/workflows/docs-deploy-surge.yml
@@ -65,7 +65,7 @@ jobs:
 
       - id: get-top-dir
         run: |
-          root=$(ls -d build/*/index.html | sed -r 's/build\/(.*)\/index\.html/\1/')
+          root=$(ls -d */index.html | sed -r 's/(.*)\/index\.html/\1/')
           echo "top-dir=$root" >> $GITHUB_OUTPUT
 
       - id: unzip-changelog

--- a/.github/workflows/docs-pr-checks.yml
+++ b/.github/workflows/docs-pr-checks.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       deploy-id: ${{ github.event.number }}
       retain-artifacts: 14
-      pageList: true
+      site-dir: 'docs'
 
   # Parse the json log output from the HTML build, and output warnings and errors as annotations
   # Optionally, fail the build if there are warnings or errors

--- a/preview.yml
+++ b/preview.yml
@@ -26,6 +26,9 @@ antora:
 urls:
   html_extension_style: indexify
 
+output:
+  dir: ./build/docs
+
 asciidoc:
   attributes:
     page-theme: docs


### PR DESCRIPTION
The default when building HTML is to output to `build/site/*`.
When this becomes the `docs.zip` artifact from a workflow, the top level dir in the zip file is `site`.
When the zip file is downloaded and extracted ready to be deployed to surge we need to deploy the contents of `./site`

Not all projects will use `site`, so we need to detect when a different dir has been defined.
(For example, the cheat-sheet uses `build/docs`.

The surge deploy workflow can detect the change and use it in the deploy step.

To use the `pageList`, which contains the source files and their respective output paths, we need to provide that as an input. to any workflows that use it.