### PR TITLE
Fix logging and warnings

### DIFF
--- a/extensions/antora/aliases-redirects/package.json
+++ b/extensions/antora/aliases-redirects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-antora/aliases-redirects",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Help with redirects and page aliases",
   "main": "aliases-redirects.js",
   "scripts": {


### PR DESCRIPTION
Fixes an issue where `page-aliases` existed but a message was still added to the log 

Also changes the `page-moved-to` attribute to `page-external`. This is an attribute that can be set in a page when it is moved from one docset to another, and `page-aliases` can't be used. Setting this attribute prevents a warning in the log, and can be used in future to generate a redirect to the new path.