### PR TITLE
New version of sitemaps extension

### DIFF
--- a/extensions/antora/antora-modify-sitemaps/README.md
+++ b/extensions/antora/antora-modify-sitemaps/README.md
@@ -26,7 +26,9 @@ Optional.
 
 Specifies a version that will be used for the sitemap for all components in the site catalog. If you do not provide a value, by default the version that Antora considers to be the latest version for a given component is used. For details on how Antora determines the 'latest' version, see [Antora version ordering rules](https://docs.antora.org/antora/latest/how-component-versions-are-sorted/#determine-version-order).
 
-You can override this value for specific components by using the `data` property.
+You might want to override this value if, for example, you publish prerelease or preview documentation of a component but you do not mark it as `prerelease: true` in the component descriptor (`antora.yml`).
+
+If you are generating output for a single component you can use `sitemap_version` to specify the version of that component that you want to generate a sitemap for. If you are generating output for multiple components, you need to override this value for specific components by using the `data` property.
 
 ### sitemap_loc_version
 

--- a/extensions/antora/antora-modify-sitemaps/README.md
+++ b/extensions/antora/antora-modify-sitemaps/README.md
@@ -22,19 +22,17 @@ antora:
 
 ### sitemap_version
 
-Required.
+Optional.
 
-Specifies a version that will be used for the sitemap for all components in the site catalog.
+Specifies a version that will be used for the sitemap for all components in the site catalog. If you do not provide a value, by default the version that Antora considers to be the latest version for a given component is used. For details on how Antora determines the 'latest' version, see [Antora version ordering rules](https://docs.antora.org/antora/latest/how-component-versions-are-sorted/#determine-version-order).
 
 You can override this value for specific components by using the `data` property.
 
-**Note:** For versionless content, where the antora.yml file specifies `version: ~`, use `sitemap_version: '~'`.
-
 ### sitemap_loc_version
 
-Optional.
+Optional. The default value is `current`.
 
-If this is specified, updates the paths in the entries in each generated sitemap file, replacing the version with the value of  `sitemap_loc_version`.
+If this is specified, the paths in the entries in each generated sitemap file are updated by replacing the version as it appears in the path with the value of `sitemap_loc_version`.
 
 For example, with `sitemap_loc_version: 'current'`
 
@@ -52,17 +50,17 @@ is updated to:
 
 ### move_sitemaps_to_components
 
-Optional.
+Optional. The default value is `true`.
 
-If set to true, the sitemap for each component will be moved to _site/\<component>/\<sitemap_version>/sitemap.xml_
+The sitemap for each component will be moved to _site/\<component>/\<sitemap_version>/sitemap.xml_ unless this attribute is set to `false`.
 
 ### data
 
 Optional.
 
-If some of your components have different versions that you want to generate a sitemap for, you can specify them with this option.
+If you want to generate a sitemap from a component by using a version that is not the latest version (as determined by Antora), you can specify the components and versions with this option.
 
-For example, if you have specified `sitemap_version: '2.0'`, but you have a component, `my-component` that is at version 1.0, you can generate a sitemap at _my-component/1.0/sitemap.xml_ with the following:
+For example, if you have a component, `my-component` and your playbook will generate output for versions `1.0` and `1.1`, you can generate a sitemap for the `1.0` content at _my-component/1.0/sitemap.xml_ with the following:
 
 ```
  data:

--- a/extensions/antora/antora-modify-sitemaps/modify-sitemaps.js
+++ b/extensions/antora/antora-modify-sitemaps/modify-sitemaps.js
@@ -42,7 +42,7 @@ module.exports.register = function ({ config }) {
       mapSite (playbook, pages) {
         const mappablePages = pages.reduce((mappable, file) => {
 
-            const mappableVersion = data.components[file.src.component] ? data.components[file.src.component] : sitemapVersion || ''
+            const mappableVersion = sitemapVersion || data.components[file.src.component] || ''
             const mappableFile = ( file.src.version == mappableVersion || ( !file.src.version && !mappableVersion ) )
 
             if (mappableFile) {
@@ -127,7 +127,7 @@ module.exports.register = function ({ config }) {
     // components without sitemaps
     for (const component in excludeVersions) {
       if (!Object.keys(mappableComponentVersions).includes(component)) {
-        const mappableVersion = data.components[component] ? data.components[component] : sitemapVersion 
+        const mappableVersion = sitemapVersion || data.components[component]
         logger.warn({  }, 'Could not create sitemap for \'%s\' version \'%s\'. Available versions are \'%s\'', component, mappableVersion, excludeVersions[component].join(', ') )
       }
     }

--- a/extensions/antora/antora-modify-sitemaps/package.json
+++ b/extensions/antora/antora-modify-sitemaps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@neo4j-antora/antora-modify-sitemaps",
-  "version": "0.4.4",
-  "description": "Override default Antora sitemap generator to include only pages for the current version, and optionally move sitemaps into the component folder for the current version",
+  "version": "0.5.0",
+  "description": "Override default Antora sitemap generator to include only pages for the current versions of components, and optionally move sitemaps into the component folders for the current versions",
   "main": "modify-sitemaps.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This PR updates the modify-sitemaps extension.

It can now be used without specifying any options, which means it can be added as an extension at build time, meaning it doesn't even need to be specified in the playbook.

By default it:
- generates sitemaps for all the latest (as determined by Antora) versions of all the components that are generated from the playbook.
- moves each sitemap into the relevant _<component-name>/<version>_ folder
- updates the path for each link in the sitemap, replacing `<version>` with `current`

If you want to generate a sitemap for a version other than the latest (eg you publish a preview version of your content, but you do not mark it in antora.yml as a prerelease) you will need to include the extension in your playbook and include the config as described in the readme file.