### PR TITLE
Use semver latest for sitemaps

### DIFF
--- a/extensions/antora/antora-modify-sitemaps/modify-sitemaps.js
+++ b/extensions/antora/antora-modify-sitemaps/modify-sitemaps.js
@@ -24,14 +24,14 @@ module.exports.register = function ({ config }) {
 
     const files = contentCatalog.findBy({ family: 'nav' })
 
-    const defaultComponent = contentCatalog.resolvePage(playbook.site.startPage).src.origin.descriptor.name
-
     componentVersions = files.reduce((v, file) => {
       v.hasOwnProperty(file.src.component) ? null : v[file.src.component] = { latest: '', versions: [] }
       v[file.src.component].versions.indexOf(file.src.version) === -1 ? v[file.src.component].versions.push(file.src.version) : null
-      file.src.component === defaultComponent ? v[file.src.component].defaultComponent = 'true' : null
       return v;
     }, {});
+
+    // derive a default component from site startPage if possible
+    const defaultComponent = playbook.site.startPage ? contentCatalog.resolvePage(playbook.site.startPage).src.origin.descriptor.name : Object.keys(componentVersions)[0] ;
 
     // check latest is not a prerelease and revert to latest actual release if it is
     for (const component of Object.keys(componentVersions)) {

--- a/extensions/antora/antora-modify-sitemaps/package.json
+++ b/extensions/antora/antora-modify-sitemaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-antora/antora-modify-sitemaps",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Override default Antora sitemap generator to include only pages for the current versions of components, and optionally move sitemaps into the component folders for the current versions",
   "main": "modify-sitemaps.js",
   "scripts": {
@@ -10,5 +10,8 @@
     "antora"
   ],
   "author": "Neo4j",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "semver": "^7.6.3"
+  }
 }


### PR DESCRIPTION
Updates `antora-modify-sitemaps` so that any releases that are determined to be prereleases according to semver rules are ignored when the extension is determining which component version should be considered as the 'latest' or 'current' version for the purpose of generating a sitemap.

- Uses the [semver](https://www.npmjs.com/package/semver) package to determine if a version is a prerelease. Most of our projects do not publish preview content without marking it as prerelease in Antora, but those that do typically append `-preview` to a version number. These versions are considered prerelase by semver's rules, and will be excluded by default when deciding what version a sitemap should be generated from
- To generate a sitemap from a preview version you now need to specify the component and version using the `data` attribute as documented in the readme file. This version will override the default if the extension is registered twice, which can happen when the extension is required by the playbook but also from the Antora CLI by using the `--extension` arg. 