### PR TITLE
Allow a component to be specified for antora-add-notes

### DIFF
--- a/extensions/asciidoc/antora-add-notes/add-notes.js
+++ b/extensions/asciidoc/antora-add-notes/add-notes.js
@@ -7,13 +7,15 @@ module.exports.register = function (registry, { file, contentCatalog }) {
       if (!doc.getAttribute('page-add-notes-tags')) return reader
       if (doc.getAttribute('page-add-notes-versions') && !doc.getAttribute('page-add-notes-versions').includes(doc.getAttribute('page-version'))) return reader
       var notesModule = doc.getAttribute('page-add-notes-module') ? doc.getAttribute('page-add-notes-module') : 'ROOT';
+      var notesComponent = doc.getAttribute('page-add-notes-component') ? doc.getAttribute('page-add-notes-component') : '';
+      const notesModuleComponent = notesComponent ? `${notesComponent}:${notesModule}` : notesModule;
       var lines = reader.lines
       lines.reverse()
       var found = false
       for (var i = 0; i < lines.length; i++) {
         if (lines[i].startsWith("= ")) found = true
         if (lines[i].length == 0 && found) {
-            lines.splice(++i,0, '', 'include::'+notesModule+':partial$/notes.adoc[tags={page-add-notes-tags}]','')
+            lines.splice(++i,0, '', `include::${notesModuleComponent}:partial$/notes.adoc[tags={page-add-notes-tags}]`,'')
             lines.reverse()
             return reader
         }

--- a/extensions/asciidoc/antora-add-notes/package.json
+++ b/extensions/asciidoc/antora-add-notes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-antora/antora-add-notes",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Add asciidoc blocks into the top of pages based on page attributes",
   "main": "add-notes.js",
   "scripts": {


### PR DESCRIPTION
In multi-component builds, the extension will produce a ton of errors because the include statement for the partial can only be resolved for the default component.

This update adds support for a `page-add-notes-component` attribute that can be set to specify the component that contains the notes module, so the include statements always resolve.