### PR TITLE
Update antora-modify-sitemaps to 0.7.1

### DIFF
--- a/extensions/antora/antora-modify-sitemaps/package.json
+++ b/extensions/antora/antora-modify-sitemaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-antora/antora-modify-sitemaps",
-  "version": "0.6.1",
+  "version": "0.7.1",
   "description": "Override default Antora sitemap generator to include only pages for the current versions of components, and optionally move sitemaps into the component folders for the current versions",
   "main": "modify-sitemaps.js",
   "scripts": {


### PR DESCRIPTION
Because of some less than stellar work from me we have had to publish version 0.7.1 of the `antora-modify-sitemaps` extension. This PR just commits the updated version number for the package.