### PR TITLE
xref hash validator - run if no site url

### DIFF
--- a/extensions/antora/xref-hash-validator/package.json
+++ b/extensions/antora/xref-hash-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-antora/xref-hash-validator",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Validate xrefs in the source that target a section of a page in the same docset",
   "main": "xref-hash-validator.js",
   "scripts": {

--- a/extensions/antora/xref-hash-validator/xref-hash-validator.js
+++ b/extensions/antora/xref-hash-validator/xref-hash-validator.js
@@ -32,6 +32,12 @@ module.exports.register = function ({ config }) {
         // and internal links that target sections of other pages
         // for each file, we can add this information to file.xrefChecker, which is now part of the contentCatalog
         const { playbook, contentCatalog } = this.getVariables()
+
+        // if there's no site url in the playbooks, we can't resolve links
+        if (!playbook.site.url) {
+            logger.info('No site URL defined in playbook %s - a dummy url will be used to validate links', playbook.file)
+        }
+
         const files = contentCatalog.getFiles()
         files.forEach( (file) => {
             if (!file.out || !file.asciidoc) return
@@ -86,7 +92,7 @@ module.exports.register = function ({ config }) {
             file.xrefChecker.internalLinks.forEach((link) => {
 
                 // what is the full url of each link?
-                searchForThisURL = new URL(path.join(file.pub.url, link), playbook.site.url)
+                searchForThisURL = new URL(path.join(file.pub.url, link), (playbook.site && playbook.site.url) ? playbook.site.url : 'https://example.com')
 
                 // if there's no hash the xref is already checked by Antora
                 // this check shouldn't ever match anyway because we should have already filtered out links without hashes

--- a/extensions/antora/xref-hash-validator/xref-hash-validator.js
+++ b/extensions/antora/xref-hash-validator/xref-hash-validator.js
@@ -34,6 +34,7 @@ module.exports.register = function ({ config }) {
         const { playbook, contentCatalog } = this.getVariables()
 
         // if there's no site url in the playbooks, we can't resolve links
+        // but we can use any domain instead
         if (!playbook.site.url) {
             logger.info('No site URL defined in playbook %s - a dummy url will be used to validate links', playbook.file)
         }


### PR DESCRIPTION
If no site url is specifed in the playbook we need to provide a domain (any domain will do, as all we are doing is using it to compare two URLs).

This PR logs an info message if no site url is specified in the playbook, and uses `https://example.com` for the site URL.