### PR TITLE
Detect syntax error in asciidoc source

### DIFF
--- a/extensions/antora/xref-hash-validator/package.json
+++ b/extensions/antora/xref-hash-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-antora/xref-hash-validator",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Validate xrefs in the source that target a section of a page in the same docset",
   "main": "xref-hash-validator.js",
   "scripts": {

--- a/extensions/antora/xref-hash-validator/xref-hash-validator.js
+++ b/extensions/antora/xref-hash-validator/xref-hash-validator.js
@@ -92,6 +92,15 @@ module.exports.register = function ({ config }) {
             // check the internal links in the file
             file.xrefChecker.internalLinks.forEach((link) => {
 
+                // if the link starts with an inline macro, log a warning for bad asciidoc syntax
+                // this can happen if eg the source is link:link:...[]
+                // but mailto: is valid 
+                const macroCheck = new RegExp('^(\\w+):', 'i');
+                if (macroCheck.test(link) && !link.startsWith('mailto:')) {
+                    logger[logLevel]({ file: file.src, source: file.src.origin }, 'syntax error detected while validating xref target \'%s\'', link)
+                    return
+                }
+
                 // what is the full url of each link?
                 searchForThisURL = new URL(path.join(file.pub.url, link), (playbook.site && playbook.site.url) ? playbook.site.url : 'https://example.com')
 
@@ -107,6 +116,12 @@ module.exports.register = function ({ config }) {
                 .filter((f) => {
                     return f.pub.url === searchForThisURL.pathname
                 })[0]
+
+                // we shouldn't generate this log message, but just in case...
+                if (!targetFile) {
+                    logger[logLevel]({ file: file.src, source: file.src.origin }, 'target file %s not found for link %s', searchForThisURL.pathname, link)
+                    return
+                }
 
                 const hashTarget = decodeURI(searchForThisURL.hash.replace('#', ''))
 


### PR DESCRIPTION
Another small tweak to the xref-hash-validator

This PR checks for and logs issues caused by bad asciidoc such as `link:link:...[]`. In this instance, the `href` on the anchor tag in the generated HTML starts with `link:`, which we can detect and log.