### PR TITLE
Better table footnotes extension

### DIFF
--- a/.github/workflows/docs-deploy-surge.yml
+++ b/.github/workflows/docs-deploy-surge.yml
@@ -64,7 +64,9 @@ jobs:
         run: unzip docs.zip
 
       - id: get-top-dir
+        shell: bash
         run: |
+          ls -lR
           root=$(ls -d **/sitemap.xml | sed -r 's/([^\/]*).*/\1/')
           echo "top-dir=$root" >> $GITHUB_OUTPUT
 

--- a/extensions/antora/table-footnotes/README.md
+++ b/extensions/antora/table-footnotes/README.md
@@ -1,0 +1,12 @@
+# table-footnotes
+
+When footnotes appear in a table, move the footnotes from the div that is added to the end of the page, and place the footnotes in a table footer row.
+
+## Usage
+
+Add the extension in a playbook
+
+```
+antora:
+  extensions:
+  - require: "@neo4j-antora/table-footnotes"

--- a/extensions/antora/table-footnotes/package.json
+++ b/extensions/antora/table-footnotes/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@neo4j-antora/table-footnotes",
+  "version": "1.0.0",
+  "description": "Move table footnotes from the end of a page to a footer row in the table",
+  "main": "table-footnotes.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "antora"
+  ],
+  "author": "Neo4j",
+  "license": "MIT",
+  "dependencies": {
+    "node-html-parser": "^7.0.0"
+  }
+}

--- a/extensions/antora/table-footnotes/table-footnotes.js
+++ b/extensions/antora/table-footnotes/table-footnotes.js
@@ -1,0 +1,71 @@
+const { parse: parseHTML, valid } = require('node-html-parser')
+
+module.exports.register = function ({ config }) {
+
+    const {defaultLogLevel = 'info'} = config
+    const logger = this.getLogger('neo4j-table-footnotes')
+  
+    this
+    .on('pagesComposed', ({ config }) => {
+
+        const { contentCatalog } = this.getVariables()
+        const files = contentCatalog.getFiles()
+
+        function createElement(el,className = '',text = '') {
+            let output = parseHTML(`<${el}${className !== '' ? ` class="${className}"` : ''}>${text}</${el}>`)
+            return output
+        }
+
+        files.forEach( (file) => {
+            if (!file.out || !file.asciidoc) return
+            const parsed = parseHTML(file.contents.toString())
+            const footnotesDiv = parsed.getElementById('footnotes')
+            const tables = parsed.querySelectorAll('table')
+            if (!footnotesDiv || tables.length === 0) return
+
+            const logLevel = file.asciidoc.attributes['suppress-table-footnote-messages'] ? 'debug' : (file.asciidoc.attributes['table-footnotes-custom-log-level'] || defaultLogLevel)
+            
+            tables.forEach( (table) => {
+                const tableFootnotes = table.querySelectorAll('tbody a.footnote')
+                if (tableFootnotes.length === 0) return
+
+                // Get the number of columns in the table for the footnotes colspan
+                const cols = table.querySelectorAll('colgroup col').length
+
+                // create the footer
+                const tFoot = createElement('tfoot')
+                const footnoteRow = createElement('tr')
+                tFoot.firstElementChild.appendChild(footnoteRow)
+                const footnoteCell = createElement('td', 'tableblock footnote-cell')
+                footnoteCell.firstElementChild.setAttribute('colspan', cols)
+
+                // go through all the footnotes in the table
+                // for each one, find the matching footnote in the footnotes div
+                // the matching footnote will have an ID that matches the href of the footnote link
+                tableFootnotes.forEach( (footnote) => {
+                    const footnoteId = footnote.getAttribute('href').replace('#', '')
+                    const matchingFootnote = footnotesDiv.querySelector(`#${footnoteId}`)
+                    if (!matchingFootnote) return
+                    // If we found a matching footnote, we can add it to the td
+                    footnoteCell.firstElementChild.appendChild(matchingFootnote)
+                })
+
+                footnoteRow.firstElementChild.appendChild(footnoteCell)
+                table.appendChild(tFoot)
+
+                // log the change
+                logger[logLevel]({ file: file.src, source: file.src.origin }, 
+                    '%d footnote%s added to %s', 
+                    tableFootnotes.length, tableFootnotes.length === 1 ? '' : 's', 
+                    table.querySelector('caption') ? table.querySelector('caption').textContent : 'table'
+                )
+            })
+            // remove the footnotes div if it contains no footnotes
+            if (footnotesDiv.querySelectorAll('div.footnote').length === 0) {
+                footnotesDiv.remove()
+                logger[logLevel]({ file: file.src, source: file.src.origin }, 'All footnotes moved to table footers: footnote div removed')
+            }
+            file.contents = Buffer.from(parsed.toString())
+        })
+    })
+}

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -15,3 +15,53 @@ For more information, see <<section-with-id>>.
 == Section with ID to test xref validator
 
 Lorem ipsum.
+
+
+== A table with footnote
+
+.Table with footnotes
+[options="header", cols="5,10"]
+|===
+| Col 1
+| Col 2
+
+| Lorem Ipsum footnote:[Footnote 1 in the table.]
+| The footnote footer row cell will span the full table width
+
+| Lorem Ipsum footnote:[Footnote 2 in the table.]
+| The footnote footer row cell will span the full table width
+
+|===
+
+== A random footnote
+
+A footnote that is not in a table footnote:[Footnote not in a table.]
+
+
+== Another table with footnote
+
+.Table with footnotes
+[options="header", cols="5,5,3,3,3"]
+|===
+| Col 1
+| Col 2
+| Col 3
+| Col 4
+| Col 5
+
+| Lorem Ipsum footnote:[Footnote 1 in the table.]
+| The footnote footer row cell will span the full table width
+|
+|
+|
+
+| Lorem Ipsum footnote:[Footnote 2 in the table.]
+| The footnote footer row cell will span the full table width
+|
+|
+|
+
+|===
+
+
+

--- a/preview.yml
+++ b/preview.yml
@@ -21,7 +21,11 @@ urls:
   html_extension_style: indexify
 
 output:
-  dir: ./build/docs
+  dir: ./build/site
+
+antora:
+  extensions:
+  - "./extensions/antora/table-footnotes"
 
 asciidoc:
   attributes:


### PR DESCRIPTION
Replaces the existing asciidoc extension with a new Antora extension.

Performs the same function, but in fewer lines, doesn't result in the `possible invalid reference` log messages, and allows us to add log messages of our own when footnotes are moved into a table footer row.