### PR TITLE
Choose checkout ref

### DIFF
--- a/.github/workflows/docs-generate-html.yml
+++ b/.github/workflows/docs-generate-html.yml
@@ -1,5 +1,5 @@
 
-name: "Generate and Publish HTML"
+name: "Generate HTML"
 
 # edit the list of branches according to your repository
 # the list of branches should contain all the branches in your Antora publish playbooks

--- a/.github/workflows/docs-generate-html.yml
+++ b/.github/workflows/docs-generate-html.yml
@@ -16,7 +16,7 @@ on:
 # `main` is the branch you use to build and publish to neo4j.com/docs
 # in some cases, PROD_BRANCH and DEV_BRANCH may be the same branch
 env:
-  PROD_BRANCH: 'main'
+  PROD_BRANCH: 'dev'
   DEV_BRANCH: 'dev'
 
 jobs:

--- a/.github/workflows/docs-generate-html.yml
+++ b/.github/workflows/docs-generate-html.yml
@@ -1,17 +1,20 @@
 
-name: "Publish HTML"
+name: "Generate and Publish HTML"
+
 
 on:
   push:
     branches:
     - 'dev'
-    # - 'main'
+    - 'main'
+    - 'test-publish'
   workflow_dispatch:
   # schedule:
   #   - cron:  '00 16 * * *'
 
 env:
   PUBLISH_TO: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
+  BUILD_FROM: ${{ github.ref == 'refs/heads/main' && 'main' || 'dev' }}
 
 jobs:
 
@@ -20,6 +23,7 @@ jobs:
     uses: ./.github/workflows/reusable-docs-build.yml
     with:
       package-script: 'verify:publish'
+      build-ref: ${{ env.BUILD_FROM }}
 
   docs-verify:
     name: Verify HTML

--- a/.github/workflows/docs-generate-html.yml
+++ b/.github/workflows/docs-generate-html.yml
@@ -8,7 +8,6 @@ on:
     branches:
     - 'dev'
     - 'main'
-    - 'test-publish'
   workflow_dispatch:
 
 # change `dev` and `main` according to your repository's branch names
@@ -25,11 +24,11 @@ jobs:
     name: Set build branch and environments
     runs-on: ubuntu-latest
     outputs:
-      build-ref: ${{ steps.set-build-ref.outputs.build-ref }}
-      environments: ${{ steps.set-build-ref.outputs.environments }}
+      build-ref: ${{ steps.set-ref-env.outputs.build-ref }}
+      environments: ${{ steps.set-ref-env.outputs.environments }}
     steps:
       - name: Set Build Ref
-        id: set-build-ref
+        id: set-ref-env
         run: |
           if [[ "${GITHUB_REF}" == "refs/heads/${{ env.DEV_BRANCH }}" ]]; then
             build_from=${{ env.DEV_BRANCH }}

--- a/.github/workflows/docs-generate-html.yml
+++ b/.github/workflows/docs-generate-html.yml
@@ -1,24 +1,26 @@
 
 name: "Generate and Publish HTML"
 
-
+# edit the list of branches according to your repository
+# the list of branches should contain all the branches in your Antora publish playbooks
 on:
   push:
     branches:
     - 'dev'
     - 'main'
-    - 'test-publish'
   workflow_dispatch:
-  # schedule:
-  #   - cron:  '00 16 * * *'
 
+# change `dev` and `main` according to your repository's branch names
+# `dev` is the branch you use to build and publish to staging
+# `main` is the branch you use to build and publish to neo4j.com/docs
 env:
-  PUBLISH_TO: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
-  BUILD_FROM: ${{ github.ref == 'refs/heads/main' && 'main' || 'dev' }}
+  PUBLISH_TO: ${{ github.ref == 'refs/heads/dev' && 'dev' || 'prod' }}
+  BUILD_FROM: ${{ github.ref == 'refs/heads/dev' && 'dev' || 'main' }}
 
 jobs:
 
-  set-ref:
+  set-build-ref:
+    name: Set build branch
     runs-on: ubuntu-latest
     outputs:
       build-ref: ${{ steps.set-build-ref.outputs.build-ref }}
@@ -29,11 +31,11 @@ jobs:
 
   docs-build:
     name: Generate HTML
-    needs: set-ref
+    needs: set-build-ref
     uses: ./.github/workflows/reusable-docs-build.yml
     with:
       package-script: 'verify:publish'
-      build-ref: ${{needs.set-ref.outputs.build-ref}}
+      build-ref: ${{needs.set-build-ref.outputs.build-ref}}
 
   docs-verify:
     name: Verify HTML

--- a/.github/workflows/docs-generate-html.yml
+++ b/.github/workflows/docs-generate-html.yml
@@ -8,14 +8,15 @@ on:
     branches:
     - 'dev'
     - 'main'
+    - 'test-publish'
   workflow_dispatch:
 
 # change `dev` and `main` according to your repository's branch names
 # `dev` is the branch you use to build and publish to staging
 # `main` is the branch you use to build and publish to neo4j.com/docs
 env:
-  PUBLISH_TO: ${{ github.ref == 'refs/heads/dev' && 'dev' || 'prod' }}
-  BUILD_FROM: ${{ github.ref == 'refs/heads/dev' && 'dev' || 'main' }}
+  PROD_BRANCH: 'main'
+  DEV_BRANCH: 'dev'
 
 jobs:
 
@@ -27,7 +28,16 @@ jobs:
     steps:
       - name: Set Build Ref
         id: set-build-ref
-        run: echo "build-ref=${{ env.BUILD_FROM }}" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "${GITHUB_REF}" == "refs/heads/${{ env.DEV_BRANCH }}" ]]; then
+            build_from=${{ env.DEV_BRANCH }}
+            publish_to='dev'
+          else
+            build_from=${{ env.PROD_BRANCH }}
+            publish_to='prod'
+          fi
+          echo "build-ref=${build_from}" >> $GITHUB_OUTPUT
+          echo "PUBLISH_TO=${publish_to}" >> $GITHUB_ENV
 
   docs-build:
     name: Generate HTML

--- a/.github/workflows/docs-generate-html.yml
+++ b/.github/workflows/docs-generate-html.yml
@@ -29,6 +29,7 @@ jobs:
 
   docs-build:
     name: Generate HTML
+    needs: set-ref
     uses: ./.github/workflows/reusable-docs-build.yml
     with:
       package-script: 'verify:publish'

--- a/.github/workflows/docs-generate-html.yml
+++ b/.github/workflows/docs-generate-html.yml
@@ -18,12 +18,21 @@ env:
 
 jobs:
 
+  set-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      build-ref: ${{ steps.set-build-ref.outputs.build-ref }}
+    steps:
+      - name: Set Build Ref
+        id: set-build-ref
+        run: echo "build-ref=${{ env.BUILD_FROM }}" >> $GITHUB_OUTPUT
+
   docs-build:
     name: Generate HTML
     uses: ./.github/workflows/reusable-docs-build.yml
     with:
       package-script: 'verify:publish'
-      build-ref: ${{ env.BUILD_FROM }}
+      build-ref: ${{needs.set-ref.outputs.build-ref}}
 
   docs-verify:
     name: Verify HTML

--- a/.github/workflows/docs-generate-html.yml
+++ b/.github/workflows/docs-generate-html.yml
@@ -51,6 +51,7 @@ jobs:
     with:
       package-script: 'verify:publish'
       build-ref: ${{needs.prepare-ref-env.outputs.build-ref}}
+      fetch-depth: 0
 
   docs-verify:
     name: Verify HTML

--- a/.github/workflows/docs-generate-html.yml
+++ b/.github/workflows/docs-generate-html.yml
@@ -14,38 +14,44 @@ on:
 # change `dev` and `main` according to your repository's branch names
 # `dev` is the branch you use to build and publish to staging
 # `main` is the branch you use to build and publish to neo4j.com/docs
+# in some cases, PROD_BRANCH and DEV_BRANCH may be the same branch
 env:
   PROD_BRANCH: 'main'
   DEV_BRANCH: 'dev'
 
 jobs:
 
-  set-build-ref:
-    name: Set build branch
+  prepare-ref-env:
+    name: Set build branch and environments
     runs-on: ubuntu-latest
     outputs:
       build-ref: ${{ steps.set-build-ref.outputs.build-ref }}
+      environments: ${{ steps.set-build-ref.outputs.environments }}
     steps:
       - name: Set Build Ref
         id: set-build-ref
         run: |
           if [[ "${GITHUB_REF}" == "refs/heads/${{ env.DEV_BRANCH }}" ]]; then
             build_from=${{ env.DEV_BRANCH }}
-            publish_to='dev'
+            environments='["dev"]'
           else
             build_from=${{ env.PROD_BRANCH }}
-            publish_to='prod'
+            environments='["prod"]'
+          fi
+          # if dev branch = prod branch publish to both
+          if [[ "${{ env.DEV_BRANCH }}" == "${{ env.PROD_BRANCH }}" ]]; then
+            environments='["dev","prod"]'
           fi
           echo "build-ref=${build_from}" >> $GITHUB_OUTPUT
-          echo "PUBLISH_TO=${publish_to}" >> $GITHUB_ENV
+          echo "environments=${environments[@]}" >> $GITHUB_OUTPUT
 
   docs-build:
     name: Generate HTML
-    needs: set-build-ref
+    needs: prepare-ref-env
     uses: ./.github/workflows/reusable-docs-build.yml
     with:
       package-script: 'verify:publish'
-      build-ref: ${{needs.set-build-ref.outputs.build-ref}}
+      build-ref: ${{needs.prepare-ref-env.outputs.build-ref}}
 
   docs-verify:
     name: Verify HTML
@@ -56,11 +62,15 @@ jobs:
 
   publish-html:
     name: Publish HTML
-    needs: docs-verify
+    needs: [docs-verify, prepare-ref-env]
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        environments: ${{ fromJson(needs.prepare-ref-env.outputs.environments) }}
+
     steps:
-      - name: Trigger Publish
+      - name: Publish to ${{ matrix.environments }}
         uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2.1.2
         with:
           token: ${{ secrets.DOCS_DISPATCH_TOKEN }}
@@ -72,5 +82,5 @@ jobs:
               "repo": "${{ github.event.repository.name }}",
               "run_id": "${{ github.run_id }}",
               "args": "--dryrun",
-              "publish_env": "${{ env.PUBLISH_TO }}"
+              "publish_env": "${{ matrix.environments }}"
             }

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -80,7 +80,7 @@ jobs:
     env:
       PACKAGE_SCRIPT: ${{ inputs.package-script }}
       DEPLOY_ID: ${{ inputs.deploy-id }}
-      BUILD_REF: ${{ inputs.build-ref || github.event.pull_request.head.sha || github.head_ref }}
+      BUILD_REF: ${{ inputs.build-ref || '' }}
       ANTORA_CLI_OPTIONS: ${{ inputs.antora-cli-options }}
       ANTORA_UI_BUNDLE_URL: ${{ inputs.antora-ui-bundle-url }}
       ANTORA_ATTRIBUTES: ${{ inputs.antora-attributes }}

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -80,7 +80,7 @@ jobs:
     env:
       PACKAGE_SCRIPT: ${{ inputs.package-script }}
       DEPLOY_ID: ${{ inputs.deploy-id }}
-      BUILD_REF: ${{ inputs.build-ref || github.head_ref }}
+      BUILD_REF: ${{ inputs.build-ref || github.event.pull_request.head.sha || github.head_ref }}
       ANTORA_CLI_OPTIONS: ${{ inputs.antora-cli-options }}
       ANTORA_UI_BUNDLE_URL: ${{ inputs.antora-ui-bundle-url }}
       ANTORA_ATTRIBUTES: ${{ inputs.antora-attributes }}

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -80,7 +80,7 @@ jobs:
     env:
       PACKAGE_SCRIPT: ${{ inputs.package-script }}
       DEPLOY_ID: ${{ inputs.deploy-id }}
-      BUILD_REF: ${{ inputs.ref || github.ref_name }}
+      BUILD_REF: ${{ inputs.build-ref || github.ref_name }}
       ANTORA_CLI_OPTIONS: ${{ inputs.antora-cli-options }}
       ANTORA_UI_BUNDLE_URL: ${{ inputs.antora-ui-bundle-url }}
       ANTORA_ATTRIBUTES: ${{ inputs.antora-attributes }}

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: ''
+      fetch-depth:
+        description: 'The git fetch depth: 1 to fetch just the ref (branch or tag), 0 for full history'
+        required: false
+        type: number
+        default: 1
       package-script:
         description: 'The name of the script to run in package.json '
         type: string
@@ -81,6 +86,7 @@ jobs:
       PACKAGE_SCRIPT: ${{ inputs.package-script }}
       DEPLOY_ID: ${{ inputs.deploy-id }}
       BUILD_REF: ${{ inputs.build-ref || '' }}
+      FETCH_DEPTH: ${{ inputs.fetch-depth || 1 }}
       ANTORA_CLI_OPTIONS: ${{ inputs.antora-cli-options }}
       ANTORA_UI_BUNDLE_URL: ${{ inputs.antora-ui-bundle-url }}
       ANTORA_ATTRIBUTES: ${{ inputs.antora-attributes }}
@@ -93,6 +99,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ env.BUILD_REF }}
+        fetch-depth: ${{ env.FETCH_DEPTH }}
 
     - name: Remove excluded extensions
       run: |

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -80,7 +80,7 @@ jobs:
     env:
       PACKAGE_SCRIPT: ${{ inputs.package-script }}
       DEPLOY_ID: ${{ inputs.deploy-id }}
-      BUILD_REF: ${{ inputs.build-ref || github.ref_name }}
+      BUILD_REF: ${{ inputs.build-ref || github.head_ref }}
       ANTORA_CLI_OPTIONS: ${{ inputs.antora-cli-options }}
       ANTORA_UI_BUNDLE_URL: ${{ inputs.antora-ui-bundle-url }}
       ANTORA_ATTRIBUTES: ${{ inputs.antora-attributes }}

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -3,6 +3,11 @@ name: Generate HTML
 on:
   workflow_call:
     inputs:
+      build-ref:
+        description: 'The git ref (branch or tag) to checkout'
+        required: false
+        type: string
+        default: ''
       package-script:
         description: 'The name of the script to run in package.json '
         type: string
@@ -75,6 +80,7 @@ jobs:
     env:
       PACKAGE_SCRIPT: ${{ inputs.package-script }}
       DEPLOY_ID: ${{ inputs.deploy-id }}
+      BUILD_REF: ${{ inputs.ref || github.ref_name }}
       ANTORA_CLI_OPTIONS: ${{ inputs.antora-cli-options }}
       ANTORA_UI_BUNDLE_URL: ${{ inputs.antora-ui-bundle-url }}
       ANTORA_ATTRIBUTES: ${{ inputs.antora-attributes }}
@@ -84,7 +90,9 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v4        
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ env.BUILD_REF }}
 
     - name: Remove excluded extensions
       run: |

--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: docs-tools
 title: Docs Tools
-version: 'dev'
+version: 'test-publish'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc

--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: docs-tools
 title: Docs Tools
-version: 'test-publish'
+version: 'dev'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc


### PR DESCRIPTION
Assume you publish to staging from `dev` and to neo4j.com from `main`.
Assume also that you publish from a branch called `1.0` and you want to publish that branch to staging and prod.

IOW, your publish.ym playbook in both branches has `branches: ['HEAD', '1.0']`.

If you push a commit to `dev`, you want to publish to the staging environment.
If you push a commit to `main`, you want to publish to the production environment.
If you push a commit to `1.0` you also want to publish (ideally to both, but we will have to choose one because we can only run the workflow once, so we choose prod).

So you define an environment variable specifying the branch to build from.
You can't pass an env var to a reusable workflow so we need to create a step to capture that var and add it to `$GITHUB_OUTPUT`.
We can then use the value as an input in the reusable workflow.

When we push a commit to the `1.0` branch, we can tell the reusable workflow to checkout the `main` branch and use that to build.

If no value for the input is provided, `env.BUILD_REF` in the reusable workflow is empty, and the default branch is used (which in the case of a PR, turns out to be the slightly secret merge commit that GitHub quietly generates for a PR)

This PR also fixes an issue where we need to fetch the whole repo history in order to build from publish playbooks, because we use relative paths to specify the sources, and we build (sometimes) from multiple branches when generating HTML for publishing.