### PR TITLE
Allow definable node version, set Antora version

### DIFF
--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -141,10 +141,10 @@ jobs:
     - name: Update all packages
       run: npm update
 
-    - name: Use Antora 3.1.12
+    - name: Use Antora 3.1.14
       run: |
         npm uninstall @antora/cli @antora/site-generator-default
-        npm install antora@3.1.12
+        npm install antora@3.1.14
 
     - name: List packages
       run: npm list

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: number
         default: 1
+      node-version:
+        description: 'The Node.js version to use'
+        required: false
+        type: string
+        default: '20'
       package-script:
         description: 'The name of the script to run in package.json '
         type: string
@@ -84,6 +89,7 @@ jobs:
 
     env:
       PACKAGE_SCRIPT: ${{ inputs.package-script }}
+      NODE_VERSION: ${{ inputs.node-version }}
       DEPLOY_ID: ${{ inputs.deploy-id }}
       BUILD_REF: ${{ inputs.build-ref || '' }}
       FETCH_DEPTH: ${{ inputs.fetch-depth }}
@@ -118,10 +124,10 @@ jobs:
         done
         echo "ANTORA_CLI_EXTENSIONS=${antora_cli_extensions}" >> $GITHUB_ENV
 
-    - name: Use Node.js 18
+    - name: Use Node.js version ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: ${{ env.NODE_VERSION }}
 
     - name: Install dependencies
       run: npm install --omit=dev


### PR DESCRIPTION
- Set Node.js default to version 20
- Use Antora 3.1.14 (avoids 3.1.13 which we can't use because the ui-bundle.zip is not correctly downloaded. See [this issue](https://antora.zulipchat.com/#narrow/channel/282400-users/topic/.E2.9C.94.20Builds.20do.20not.20produce.20output.20with.20Antora.203.2E1.2E13/with/543013463) raised against it)