### PR TITLE
DOCOPS-40: Improve xref-hash-validator logging

### DIFF
--- a/extensions/antora/xref-hash-validator/package.json
+++ b/extensions/antora/xref-hash-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-antora/xref-hash-validator",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Validate xrefs in the source that target a section of a page in the same docset",
   "main": "xref-hash-validator.js",
   "scripts": {

--- a/extensions/antora/xref-hash-validator/xref-hash-validator.js
+++ b/extensions/antora/xref-hash-validator/xref-hash-validator.js
@@ -174,7 +174,7 @@ module.exports.register = function ({ config }) {
                     // the pages you could link to (possibleSources) instead are the files that do contain this anchor (hashTarget)
                     // we can log each of these
                     const possibleSources = linkTargets[hashTarget].map( (f) => {
-                        return `${f.src} (branch: ${f.branch})`
+                        return `${f.src} (component: ${f.component}, branch: ${f.branch})`
                     }).join(', ')
 
                     logger[logLevel]({ file: file.src, source: file.src.origin }, 'section %s not found in target page %s (branch: %s) - anchor found in %s', decodeURI(searchForThisURL.hash), targetFile.src.path, targetFile.src.origin.branch, possibleSources)      


### PR DESCRIPTION
It's possible that an xref hash target exists in a file that is in a different component from the source file. (Or, in the case of drivers documentation, where partials are re-used in multiple components, the target can be reported as existing in multiple components). It would be helpful in that situation for the log to include the component name to make troubleshooting the link easier.