### PR TITLE
DOCOPS-53 Add Aura Graph Analytics label

### DIFF
--- a/extensions/antora/roles-labels/data/roles.json
+++ b/extensions/antora/roles-labels/data/roles.json
@@ -304,6 +304,24 @@
                 ]
             }
         },
+        "aura-graph-analytics":{
+            "description": "Function available in Aura Graph Analytics",
+            "labelCategory": "product",
+            "product": "Aura Graph Analytics",
+            "displayText": "Aura Graph Analytics",
+            "usage": {
+                "page-role": [
+                    ":page-role: aura-graph-analytics"
+                ],
+                "role": [
+                    "[role=label--aura-graph-analytics]"
+                ],
+                "inline": [
+                    "label:aura-graph-analytics[]"
+                ]
+            }
+        },
+
         "aura-ds-enterprise":{
             "description": "Function available in AuraDS Enterprise",
             "labelCategory": "product",

--- a/extensions/antora/roles-labels/package.json
+++ b/extensions/antora/roles-labels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-antora/roles-labels",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Convert roles on a block to a labels div, add dataset info to a block based on roles and inline labels",
   "main": "roles-labels.js",
   "scripts": {

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -112,3 +112,12 @@ Lorem ipsum.
 ====
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ====
+
+
+[role=label--aura-graph-analytics]
+== Aura Graph Analytics label
+
+This section is marked with the Aura Graph Analytics label.
+
+- label:aura-graph-analytics[] list item with label
+- List item without label


### PR DESCRIPTION
Adds a new label to the `roles-labels` extension for Aura Graph Analytics.