### PR TITLE
DOCOPS-67 Fix terms marked in links

### DIFF
--- a/extensions/asciidoc/mark-terms/mark-terms.js
+++ b/extensions/asciidoc/mark-terms/mark-terms.js
@@ -107,9 +107,17 @@ module.exports = function (registry) {
             return line
           }
 
+          // handle xref shorthand <<Term>> → <<Term, markedTerm>> to preserve the reference target
+          if (line.includes(`<<${safeTerm}>>`)) {
+            doc.getLogger().info(`(mark-terms) marked '${safeTerm}'`)
+            markAdded.push(safeTerm)
+            return line.replace(`<<${safeTerm}>>`, `<<${safeTerm}, ${safelyMarkedTerm}>>`)
+          }
+
           // mark the first instance of the term if we find a match
           if (line.includes(safeTerm)) {
             doc.getLogger().info(`(mark-terms) marked '${safeTerm}'`)
+            markAdded.push(safeTerm)
             return line.replace(safeTerm, safelyMarkedTerm)
           }
 

--- a/extensions/asciidoc/mark-terms/package.json
+++ b/extensions/asciidoc/mark-terms/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@neo4j-antora/mark-terms",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "Asciidoc extension to mark the first instance of a term on a page, typically with a copyright symbol",
     "main": "mark-terms.js",
     "scripts": {
@@ -10,7 +10,7 @@
       "type": "git",
       "url": "git+https://github.com/neo4j/docs-tools.git"
     },
-    "author": "Neo4j Documentation <docs@neo4j,com>",
+    "author": "Neo4j Documentation <docs@neo4j.com>",
     "license": "MIT",
     "bugs": {
       "url": "https://github.com/neo4j/docs-tools/issues"

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -22,6 +22,31 @@ Testing the `new` label:
 - with valid alternative text: label:new-2025.11[Added in 2025.11].
 - versionless: label:new[Added].
 
+
+[[mark-terms-test]]
+== Test the mark terms extension
+
+Lorem ipsum
+
+
+== Section containing xrefs to another section
+
+For more information, see <<mark-terms-test>>
+
+For this next link we are going to use a marked term in the link text.
+For more information, see <<Cypher>>
+In the same paragraph, to verify that we only mark the first usage, this link goes to a section where the ID is a marked term: <<Cypher>>.
+And this is just a plain text instance of the term Cypher.
+
+We can also test links where the link text is specified, for example <<Cypher, test term>>.
+
+
+[[Cypher]]
+== The ID of this section is Cypher
+
+Lorem ipsum dolor sit etc.
+
+
 [role=label--enterprise-edition]
 == A table with footnote
 

--- a/preview.yml
+++ b/preview.yml
@@ -48,4 +48,4 @@ asciidoc:
     includePDF: false
     nonhtmloutput: ""
     neo4j-docs-base-uri: https://neo4j.com/docs
-    page-terms-to-mark: Neo4j, Cypher
+    page-terms-to-mark: Neo4j, Cypher, test term


### PR DESCRIPTION
This PR fixes a bug in the `mark-terms` extension where it was not handling `<<...>>` links correctly.