### PR TITLE
DOCOPS-94 Handle footnote in admonition

### DIFF
--- a/extensions/antora/table-footnotes/package.json
+++ b/extensions/antora/table-footnotes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-antora/table-footnotes",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Move table footnotes from the end of a page to a footer row in the table",
   "main": "table-footnotes.js",
   "scripts": {

--- a/extensions/antora/table-footnotes/table-footnotes.js
+++ b/extensions/antora/table-footnotes/table-footnotes.js
@@ -35,8 +35,12 @@ module.exports.register = function ({ config }) {
                 const tableFootnotes = table.querySelectorAll('a.footnote')
                 if (tableFootnotes.length === 0) return
 
+                const admonTable = table.parentNode.classList.contains('admonitionblock')
+
                 // Get the number of columns in the table for the footnotes colspan
-                const cols = table.querySelectorAll('colgroup col').length
+                const cols = admonTable
+                    ? '2'
+                    : table.querySelectorAll('colgroup col').length
 
                 // create the footer
                 const existingTFoot = table.querySelector('tfoot')
@@ -46,6 +50,11 @@ module.exports.register = function ({ config }) {
                 else tFoot.appendChild(footnoteRow)
                 const footnoteCell = createElement('td', 'tableblock footnote-cell')
                 footnoteCell.firstElementChild.setAttribute('colspan', cols)
+
+                if (admonTable) {
+                    const contentClasses = table.querySelector('td.content').classList.value
+                    contentClasses.forEach(cls => footnoteCell.firstElementChild.classList.add(cls))
+                }
 
                 // go through all the footnotes in the table
                 // for each one, find the matching footnote in the footnotes div

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -5,6 +5,47 @@
 Use these docs to test workflows and extensions.
 
 
+== Admonition with footnote
+
+Admonitions are rendered as tables.
+The table-footnotes extension needs to be able to handle that.
+
+[NOTE]
+====
+This is a note with some paragraphs.
+
+This paragraph contains a footnote that needs to be rendered footnote:admonfoot[Footnote 1].
+====
+
+
+== Admonition with table, with footnotes
+
+What if the admonition contains a table, and the table itself contains footnotes?
+
+[NOTE]
+====
+Table inside a table?
+
+.Table with footnotes
+[options="header", cols="5,10"]
+|===
+| Col 1
+| Col 2
+
+| Lorem Ipsum footnote:[Footnote 1 in the table.]
+| The footnote footer row cell will span the full table width
+
+| Lorem Ipsum footnote:[Footnote 2 in the table.]
+| The footnote footer row cell will span the full table width
+
+|===
+
+====
+
+== Admonition with table, with footnotes
+
+[NOTE]
+
 == Include test
 
 include::partial$include-target.adoc[]


### PR DESCRIPTION
This PR adds support for footnotes inside admonition blocks.

Previously the extension counted colgroup col elements for the colspan, but admonition tables don't use colgroups — they have a fixed 2-column structure (icon + content).
The fix detects whether the table is inside an .admonitionblock, sets the colspan to 2, and copies the CSS classes from td.content onto the footnote cell so it inherits the correct styling.