### PR TITLE
Bump default Antora to 3.1.15 and expose antora-version input

### DIFF
--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: string
         default: '24'
+      antora-version:
+        description: 'The Antora version to install'
+        required: false
+        type: string
+        default: '3.1.15'
       package-script:
         description: 'The name of the script to run in package.json '
         type: string
@@ -99,6 +104,7 @@ jobs:
     env:
       PACKAGE_SCRIPT: ${{ inputs.package-script }}
       NODE_VERSION: ${{ inputs.node-version }}
+      ANTORA_VERSION: ${{ inputs.antora-version }}
       DEPLOY_ID: ${{ inputs.deploy-id }}
       BUILD_REF: ${{ inputs.build-ref || '' }}
       FETCH_DEPTH: ${{ inputs.fetch-depth }}
@@ -173,7 +179,7 @@ jobs:
         # Ensure correct version of Antora
         printf "\n\n<!---- Ensure correct version of Antora -->"
         npm uninstall @antora/cli @antora/site-generator-default
-        npm install antora@3.1.14
+        npm install antora@$ANTORA_VERSION
         
         # List installed packages
         printf "\n\n<!---- Installed packages -->\n"


### PR DESCRIPTION
## Summary
- Bumps the default Antora version installed by the reusable build workflow from `3.1.14` to `3.1.15`.
- Adds an `antora-version` workflow input (default `3.1.15`) so callers can override it without another change here next time.

## Why
Antora 3.1.14 silently no-ops on Node 24.16+ runners — yauzl 3.1.3 read streams stall during UI bundle zip load, so antora hangs in the loader, the JSON file logger never flushes, and the process eventually exits 0 with `build/log/log.json` at 0 bytes and no `sitemap.xml`. Antora 3.1.15 rolls up yauzl 3.3.1 which fixes the regression upstream.

Upstream issue: https://gitlab.com/antora/antora/-/work_items/1214

## Test plan
- [x] Verified on a test PR (now closed, #89) that bumping to 3.1.15 makes the full build chain pass: build, verify, page-list/changelog comment all green.
- [ ] Merge and confirm consumer repos (docs-http-api, docs-dataflow-connector, etc.) go green on their next push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)