### PR TITLE
Fix: table-footnotes extension only moved the first footnote per page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ vale/styles/Google
 package-lock.json
 node_modules/
 .env
+.claude

--- a/extensions/antora/table-footnotes/package.json
+++ b/extensions/antora/table-footnotes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-antora/table-footnotes",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Move table footnotes from the end of a page to a footer row in the table",
   "main": "table-footnotes.js",
   "scripts": {

--- a/extensions/antora/table-footnotes/table-footnotes.js
+++ b/extensions/antora/table-footnotes/table-footnotes.js
@@ -25,9 +25,12 @@ module.exports.register = function ({ config }) {
             }
 
             const parsed = parseHTML(file.contents.toString())
-            const footnotesDiv = parsed.getElementById('footnotes')
+            // AsciiDoc-styled table cells are rendered as nested documents, so a single
+            // page can contain several "footnotes" divs: one at the page level plus one
+            // inside each such cell that defines a footnote. Collect them all.
+            const footnotesDivs = parsed.querySelectorAll('[id="footnotes"]')
             const tables = parsed.querySelectorAll('table')
-            if (!footnotesDiv || tables.length === 0) return
+            if (footnotesDivs.length === 0 || tables.length === 0) return
 
             const logLevel = file.asciidoc.attributes['suppress-table-footnote-messages'] ? 'debug' : (file.asciidoc.attributes['table-footnotes-custom-log-level'] || defaultLogLevel)
             
@@ -61,7 +64,9 @@ module.exports.register = function ({ config }) {
                 // the matching footnote will have an ID that matches the href of the footnote link
                 tableFootnotes.forEach( (footnote) => {
                     const footnoteId = footnote.getAttribute('href').replace('#', '')
-                    const matchingFootnote = footnotesDiv.querySelector(`#${footnoteId}`)
+                    // The matching definition may live in any of the page's footnotes divs
+                    // (page-level or inside another cell), so search the whole document.
+                    const matchingFootnote = parsed.querySelector(`#${footnoteId}`)
                     if (!matchingFootnote) return
                     // If we found a matching footnote, we can add it to the td
                     footnoteCell.firstElementChild.appendChild(matchingFootnote)
@@ -77,11 +82,13 @@ module.exports.register = function ({ config }) {
                     table.querySelector('caption') ? table.querySelector('caption').textContent : 'table'
                 )
             })
-            // remove the footnotes div if it contains no footnotes
-            if (footnotesDiv.querySelectorAll('div.footnote').length === 0) {
-                footnotesDiv.remove()
-                logger[logLevel]({ file: file.src, source: file.src.origin }, 'All footnotes moved to table footers: footnote div removed')
-            }
+            // remove any footnotes div that no longer contains footnotes
+            footnotesDivs.forEach( (footnotesDiv) => {
+                if (footnotesDiv.querySelectorAll('div.footnote').length === 0) {
+                    footnotesDiv.remove()
+                    logger[logLevel]({ file: file.src, source: file.src.origin }, 'All footnotes moved to table footers: footnote div removed')
+                }
+            })
             file.contents = Buffer.from(parsed.toString())
         })
     })

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -5,21 +5,9 @@
 Use these docs to test workflows and extensions.
 
 
-== table footnotes
+== Verify table footnotes
 
-.JSON format log entries for log type `query`
-[cols="2m,3a", options="header"]
-|===
-| Name
-| Description
-
-| authenticatedUser
-| The username footnote:[simple footnote]
-
-| authenticatedUser
-| The username footnote:[simple footnote]
-
-|===
+A bug was found where footnotes were not handled correctly in cells where asciidoc format was specified.
 
 .JSON format log entries for log type `query`
 [cols="2m,3a", options="header"]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -5,6 +5,37 @@
 Use these docs to test workflows and extensions.
 
 
+== table footnotes
+
+.JSON format log entries for log type `query`
+[cols="2m,3a", options="header"]
+|===
+| Name
+| Description
+
+| authenticatedUser
+| The username footnote:[simple footnote]
+
+| authenticatedUser
+| The username footnote:[simple footnote]
+
+|===
+
+.JSON format log entries for log type `query`
+[cols="2m,3a", options="header"]
+|===
+| Name
+| Description
+
+| authenticatedUser
+| The username footnote:[simple footnote]
+
+| authenticatedUser
+| The username footnote:[simple footnote]
+
+|===
+
+
 == Admonition with footnote
 
 Admonitions are rendered as tables.


### PR DESCRIPTION
## Problem

AsciiDoc-styled table cells (a columns) are rendered by Asciidoctor as nested documents, and each one that defines a footnote emits its own `<div id="footnotes">`. A page can therefore contain several elements with `id="footnotes"`, not the single page-level one the extension assumed.

Because of this, only the first footnote on a page was moved into its table footer. Every subsequent footnote's definition lived in a different `#footnotes` div, so the lookup failed and the definition was left stranded inside its own table cell.

## Fix

Collect all footnotes divs with `querySelectorAll('[id="footnotes"]')` instead of grabbing only the first via `getElementById`.
Resolve each footnote definition against the whole document `(parsed.querySelector(...))` so it's found wherever it lives.
Remove every emptied footnotes div, not just one.

## Verification

Rebuilt the preview site and confirmed all footnotes now land in the correct `<tfoot>`: multi-footnote tables, header footnotes, and footnotes inside admonitions all move correctly, while a genuine non-table footnote is correctly left in the page-level footnotes section.