### PR TITLE
Add compatibility for roles-labels with old cheat sheet labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ vale/styles/Google
 package-lock.json
 node_modules/
 .env
+
+# Claude
+.claude

--- a/extensions/antora/roles-labels/data/roles.json
+++ b/extensions/antora/roles-labels/data/roles.json
@@ -13,7 +13,15 @@
         "auradb-virtual-dedicated-cloud": "aura-db-dedicated",
         "auradb-professional": "aura-db-professional",
         "aurads-enterprise": "aura-ds-enterprise",
-        "aurads-professional": "aura-ds-professional"        
+        "aurads-professional": "aura-ds-professional",
+        "neo4j-ce": "community-edition",
+        "neo4j-ee": "enterprise-edition",
+        "aura-dbf": "aura-db-free",
+        "aura-dbp": "aura-db-professional",
+        "aura-dbc": "aura-db-business-critical",
+        "aura-dbe": "aura-db-enterprise",
+        "aura-dsp": "aura-ds-professional",
+        "aura-dse": "aura-ds-enterprise"
     },
     "labels": {
         "featured": {
@@ -131,6 +139,23 @@
                 ],
                 "inline": [
                     "label:cypher-25-only[]"
+                ]
+            }
+        },
+        "community-edition":{
+            "description": "Function available in Community Edition",
+            "labelCategory": "product",
+            "product": "Neo4j Community Edition",
+            "displayText": "Community Edition",
+            "usage": {
+                "page-role": [
+                    ":page-role: community-edition"
+                ],
+                "role": [
+                    "[role=label--community-edition]"
+                ],
+                "inline": [
+                    "label:community-edition[]"
                 ]
             }
         },

--- a/extensions/antora/roles-labels/package.json
+++ b/extensions/antora/roles-labels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-antora/roles-labels",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Convert roles on a block to a labels div, add dataset info to a block based on roles and inline labels",
   "main": "roles-labels.js",
   "scripts": {

--- a/extensions/antora/roles-labels/roles-labels.js
+++ b/extensions/antora/roles-labels/roles-labels.js
@@ -4,6 +4,11 @@ const rolesData = require('./data/roles.json')
 
 const lowercaseProducts = rolesData.products.map((p) => p.toLowerCase())
 
+// synonyms can be applied as bare roles (eg [.neo4j-ee.aura-dbe]) without the label-- prefix
+// build a selector so these are picked up alongside label-- classes
+const synonymSelector = Object.keys(rolesData.synonyms).map((k) => `.${k}`).join(', ')
+const roleSelector = synonymSelector ? `[class*="label--"], ${synonymSelector}` : '[class*="label--"]'
+
 module.exports.register = function ({ config }) {
 
     const {defaultLogLevel = 'info', replaceInlineLabelText = false } = config
@@ -248,7 +253,7 @@ module.exports.register = function ({ config }) {
 
             const parsed = parseHTML(file.contents.toString())
             const headings = ['H2', 'H3', 'H4', 'H5', 'H6', 'CAPTION']
-            const roleDivs = parsed.querySelectorAll('[class*="label--"]')
+            const roleDivs = parsed.querySelectorAll(roleSelector)
             var labelCount = 0
             roleDivs.forEach(function (roleDiv) {
 
@@ -260,7 +265,7 @@ module.exports.register = function ({ config }) {
                 if (rolesClassList.contains('discrete')) return
 
                 roles = rolesClassList.value.sort().filter(function (c) {
-                    return (c.startsWith('label--'))
+                    return (c.startsWith('label--') || rolesData.synonyms[c])
                 })
 
                 if (roles.length === 0) return

--- a/extensions/antora/roles-labels/roles-labels.js
+++ b/extensions/antora/roles-labels/roles-labels.js
@@ -264,6 +264,10 @@ module.exports.register = function ({ config }) {
                 // - discrete headers
                 if (rolesClassList.contains('discrete')) return
 
+                // - the body element: page-role values render as bare classes on <body>,
+                //   but labels belong on headings/blocks, so never build a label div here
+                if (roleDiv.tagName === 'BODY') return
+
                 roles = rolesClassList.value.sort().filter(function (c) {
                     return (c.startsWith('label--') || rolesData.synonyms[c])
                 })

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,6 +1,6 @@
 = Docs tools
 :page-aliases: old-docs-tools.adoc
-:page-role: enterprise-edition
+:page-role: enterprise-edition neo4j-ce aura-dbc aura-dbe
 
 Use these docs to test workflows and extensions.
 
@@ -18,6 +18,7 @@ This paragraph contains a footnote that needs to be rendered footnote:admonfoot[
 ====
 
 
+[.neo4j-ce.aura-dbf]
 == Admonition with table, with footnotes
 
 What if the admonition contains a table, and the table itself contains footnotes?


### PR DESCRIPTION
Handle the old `neo4j-ce` labels that we used to use in the cheat sheet, just in case any persist.