### PR TITLE
DOCOPS-169 Harden docs-deploy-surge.yml (keep approve-fork gate + add validation)

### DIFF
--- a/.github/workflows/docs-deploy-surge.yml
+++ b/.github/workflows/docs-deploy-surge.yml
@@ -22,7 +22,8 @@ on:
       - completed
 
 jobs:
-  # Gate job: only runs for fork PRs, requires manual approval via the "preview" environment.
+  # [Optional] Restrict automatic deployment to PRs from the upstream repo
+  # For fork PRs, requires manual approval via the "preview" environment.
   # For PRs from the main repository this job is skipped and deploy-docs runs immediately.
   # Setup: create a "preview" environment in Settings → Environments with required reviewers.
   approve-fork:
@@ -36,8 +37,6 @@ jobs:
   deploy-docs:
     needs: [approve-fork]
     # Run when approve-fork succeeded (fork, approved) or was skipped (non-fork).
-    # Uncomment the conclusion check to deploy only when the PR builds cleanly:
-    # && github.event.workflow_run.conclusion == 'success'
     if: |
       always() &&
       (needs.approve-fork.result == 'success' || needs.approve-fork.result == 'skipped')
@@ -55,7 +54,7 @@ jobs:
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: ${{ env.RUN_ID }},
+               run_id: process.env.RUN_ID,
             });
 
             var matchArtifactDocs = artifacts.data.artifacts.filter((artifact) => {
@@ -85,13 +84,32 @@ jobs:
 
       - id: suspicious-path-check
         name: Suspicious paths check
+        shell: bash
         env:
           ARTIFACT_DIR: ${{ runner.temp }}/artifacts/docs
         run: |
+          set -euo pipefail
           cd "$ARTIFACT_DIR"
-          if unzip -l docs.zip | grep -q "\.\./"; then
+          
+          mapfile -t ZIP_ENTRIES < <(zipinfo -1 docs.zip)
+          if [ "${#ZIP_ENTRIES[@]}" -eq 0 ]; then
+            echo "docs.zip is empty"
             exit 1
           fi
+          for entry in "${ZIP_ENTRIES[@]}"; do
+            if [[ "$entry" =~ ^/ ]]; then
+              echo "Blocked absolute path in artifact: $entry"
+              exit 1
+            fi
+            if [[ "$entry" =~ (^|/)\.\.(/|$) ]]; then
+              echo "Blocked path traversal in artifact: $entry"
+              exit 1
+            fi
+            if [[ "$entry" == *\\* ]]; then
+              echo "Blocked Windows-style path separator in artifact: $entry"
+              exit 1
+            fi
+          done
 
       - id: hidden-files-check
         name: Hidden files check
@@ -130,7 +148,27 @@ jobs:
         run: |
           cd "$ARTIFACT_DIR"
           unzip changelog.zip
-      
+
+      # The changelog file is built from untrusted PR content and its contents
+      # are posted to the PR as a comment. A malicious artifact could make
+      # `changelog` a symlink pointing at an arbitrary file the runner can read,
+      # turning the comment step into an arbitrary-file-read. Reject anything
+      # that isn't a plain regular file before we read it.
+      - id: validate-changelog
+        name: Validate changelog is a regular file
+        if: ${{ steps.find-changelog.outputs.has-changelog == 'true' }}
+        env:
+          CHANGELOG_FILE: ${{ runner.temp }}/artifacts/changelog/changelog
+        run: |
+          if [ -L "$CHANGELOG_FILE" ]; then
+            echo "Security Alert: changelog is a symlink — refusing!"
+            exit 1
+          fi
+          if [ ! -f "$CHANGELOG_FILE" ]; then
+            echo "changelog missing or not a regular file"
+            exit 1
+          fi
+
       - id: get-deploy-id
         name: Get deploy ID
         env:


### PR DESCRIPTION
## What

Hardens `.github/workflows/docs-deploy-surge.yml` against artifact poisoning – **bespoke, not a blind template sync**, because docs-tools already has the **`approve-fork` gate enabled** (manual fork-PR approval via the `preview` environment), which the canonical template leaves commented out. This PR **keeps that gate** and adds the three hardening pieces docs-tools was missing:

- **`validate-changelog` step** – rejects a symlinked changelog before it's read into the PR comment.
- **`process.env.RUN_ID`** instead of `${{ env.RUN_ID }}` in the `github-script` step (avoids Actions expression injection).
- **Extended `zipinfo` suspicious-path-check** – rejects empty archives, absolute paths, path traversal (`..`), and Windows-style backslash separators.

Result = docs-template's extended validation **plus** docs-tools's existing fork-approval gate.

## Why

Found by a fleet-wide audit of `docs-deploy-surge.yml` (DOCOPS-169): the alert-driven fan-out only covered scanned repos, so un-hardened repos without CodeQL alerts (incl. docs-tools) were missed. No branch/path filters changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
