### PR TITLE
DOCOPS-171 Fix publish URL fallback logic and use org-level secrets

### DIFF
--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -123,12 +123,17 @@ jobs:
       FETCH_DEPTH: ${{ inputs.fetch-depth }}
       DOCS_DIR: ${{ inputs.docs-dir }}
       SITE_DIR: ${{ inputs.site-dir }}
-      # Publish builds use the real published URL (needed to resolve secrets, which
-      # requires the "publish-env" environment above). Everything else - including
-      # PR previews - derives the surge.sh URL it's about to be deployed to (see
+      # Publish builds use the real published URL, org secrets (DOCS_PUBLISH_URL_STAGING /
+      # DOCS_PUBLISH_URL_PROD) picked by publish-env - org-level, not per-repo, since every
+      # repo publishes under the same staging/prod roots. Everything else - including PR
+      # previews - derives the surge.sh URL it's about to be deployed to (see
       # docs-deploy-surge.yml, which computes the same $ORG-$REPO-$DEPLOYID.surge.sh
       # pattern), so nav links depending on an absolute site URL still resolve.
-      ANTORA_CLI_OPTIONS: "${{ inputs.antora-cli-options }}${{ format(' --url {0}', inputs.package-script == 'verify:publish' && secrets.DOCS_PUBLISH_URL || format('https://{0}-{1}-{2}.surge.sh', github.repository_owner, github.event.repository.name, inputs.deploy-id)) }}"
+      # The branch is decided purely by package-script - NOT compounded with whether
+      # the secret happens to have a value, so a publish build with a missing secret
+      # fails loudly (empty --url) instead of silently falling back to a fabricated,
+      # never-deployed surge URL.
+      ANTORA_CLI_OPTIONS: "${{ inputs.antora-cli-options }}${{ inputs.package-script == 'verify:publish' && format(' --url {0}', inputs.publish-env == 'staging' && secrets.DOCS_PUBLISH_URL_STAGING || secrets.DOCS_PUBLISH_URL_PROD) || format(' --url https://{0}-{1}-{2}.surge.sh', github.repository_owner, github.event.repository.name, inputs.deploy-id) }}"
       ANTORA_UI_BUNDLE_URL: "${{ inputs.package-script == 'verify:publish' && 'https://static-content.neo4j.com/build/ui-bundle-docs-restructure.zip'|| inputs.antora-ui-bundle-url }}"
       ANTORA_ATTRIBUTES: "${{ inputs.antora-attributes }}${{ inputs.package-script == 'verify:publish' && ' --attribute page-chatbot=/docs/assets/chatbot' || '' }}"
       ANTORA_EXTENSIONS: "${{ inputs.antora-extensions }}${{ inputs.package-script == 'verify:publish' && '@neo4j-antora/tabbed-nav' || '' }}"


### PR DESCRIPTION
## Summary
- Fix `ANTORA_CLI_OPTIONS`'s `--url` logic: the publish-vs-preview branch was decided by `package-script == 'verify:publish' && secrets.DOCS_PUBLISH_URL` combined, so a real publish build with no secret set silently fell through to deriving a fake, never-deployed surge URL instead of failing. This is what broke `docs-cypher`'s first `verify:publish` test (`Could not fetch nav from https://neo4j-docs-cypher-0.surge.sh/nav/tabs.json: HTTP 404`). Now the branch is decided by `package-script` alone, so a missing secret fails loudly instead.
- Switch from a single per-repo `DOCS_PUBLISH_URL` secret (which only ever existed in `docs-tools`, since reusable workflows never get access to the secrets of the repo hosting the workflow file - only the calling repo's own) to two **organization-level** secrets, `DOCS_PUBLISH_URL_STAGING` and `DOCS_PUBLISH_URL_PROD`, selected by `publish-env`. Every repo publishes under the same staging/prod roots, so this works without any per-repo setup.

## Test plan
- [x] `docs-build-pr` / `docs-verify-pr` pass on this PR (preview path, uses derived surge URL)
- [ ] Confirm a `verify:publish` run in another repo (e.g. `docs-cypher`) now resolves `DOCS_PUBLISH_URL_STAGING`/`DOCS_PUBLISH_URL_PROD` correctly via the org secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)