### PR TITLE
DOCOPS-177 Auto-detect Antora playbook branches to fetch

### DIFF
--- a/.github/workflows/docs-pr-checks.yml
+++ b/.github/workflows/docs-pr-checks.yml
@@ -18,7 +18,6 @@ jobs:
     with:
       deploy-id: ${{ github.event.number }}
       docs-dir: 'docs'
-      antora-fetch-branches: 'test/add-branches'
       sparse-checkout: false
       antora-extensions: '
           ../extensions/antora/aliases-redirects

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -195,7 +195,18 @@ jobs:
         playbook_path="${DOCS_DIR}/${ANTORA_PLAYBOOK}"
         playbook_branches=""
         if [ -f "$playbook_path" ]; then
-          playbook_branches=$(yq eval '[.content.sources[].branches] | flatten | map(select(. != "HEAD")) | unique | join(" ")' "$playbook_path")
+          # A playbook can declare multiple content sources, each from a different repo.
+          # We only checked out and can git-fetch branches for THIS repo, so only consider
+          # sources whose url is a relative/local path to it - not an absolute url (a
+          # scheme like https:// or git://, or scp-like git@host:path), which always means
+          # a different repo. Those are Antora's own problem to fetch, not ours.
+          playbook_branches=$(yq eval '
+            [.content.sources[] | select(((.url | test("^[a-zA-Z][a-zA-Z0-9+.-]*://")) or (.url | test("^[^/]+@[^:/]+:"))) | not) | .branches]
+            | flatten
+            | map(select(. != "HEAD"))
+            | unique
+            | join(" ")
+          ' "$playbook_path")
         else
           echo "::warning::Antora playbook not found at ${playbook_path}; skipping auto-detected branches"
         fi

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -76,10 +76,15 @@ on:
         type: string
         default: 'na'
       antora-fetch-branches:
-        description: 'Space-separated list of additional branches to fetch (e.g. other versions referenced by a multi-version Antora playbook). Fetched with git before the build, so Antora does not have to rely on its own --fetch (isomorphic-git), which is less reliable for this.'
+        description: 'Space-separated list of additional branches to fetch, on top of whatever is auto-detected from antora-playbook (e.g. a branch needed for a one-off reason that is not itself a playbook content source). Fetched with git before the build, so Antora does not have to rely on its own --fetch (isomorphic-git), which is less reliable for this.'
         required: false
         type: string
         default: ''
+      antora-playbook:
+        description: 'Antora playbook file, relative to docs-dir, to read multi-version branches from (content.sources[].branches). Every branch listed there - other than HEAD, which is whatever build-ref already checked out - is fetched automatically before the build, so this input does not need manual upkeep as versions are added or removed. Override only if a repo names its playbook something other than publish.yml.'
+        required: false
+        type: string
+        default: 'publish.yml'
       sparse-checkout:
         description: 'Whether to sparse-checkout only docs-dir (plus sparse-checkout-extra-paths) instead of the whole repo. Only relevant when docs-dir is not ".". Set to false to check out the whole repo, e.g. if docs-dir needs to reference sibling paths elsewhere in the repo.'
         required: false
@@ -155,6 +160,7 @@ jobs:
       ANTORA_EXTENSIONS_EXCLUDE: ${{ inputs.antora-extensions-exclude }}
       ANTORA_AI_SEARCH_LINK: "${{ inputs.package-script == 'verify:publish' && '--attribute page-chatbot=https://neo4j.com/docs/assets/chatbot' || '' }}"
       ANTORA_FETCH_BRANCHES: ${{ inputs.antora-fetch-branches }}
+      ANTORA_PLAYBOOK: ${{ inputs.antora-playbook }}
       SPARSE_CHECKOUT: ${{ inputs.sparse-checkout }}
       SPARSE_CHECKOUT_EXTRA_PATHS: ${{ inputs.sparse-checkout-extra-paths }}
 
@@ -178,13 +184,31 @@ jobs:
           ${{ env.SPARSE_CHECKOUT_EXTRA_PATHS }}
         sparse-checkout-cone-mode: false
 
-    # fetch any additional branches a multi-version Antora playbook needs, using real git
-    # (more reliable than relying on antora --fetch, which uses isomorphic-git)
-    - name: Fetch additional Antora playbook branches
-      if: ${{ env.ANTORA_FETCH_BRANCHES != '' }}
+    # Fetch every branch a multi-version Antora playbook needs, using real git (more
+    # reliable than relying on antora --fetch, which uses isomorphic-git). Branches come
+    # from two places, unioned: content.sources[].branches in antora-playbook (read
+    # automatically - HEAD is excluded, since that's whatever build-ref already checked
+    # out, not a separate branch to fetch) and the antora-fetch-branches input (a manual
+    # escape hatch for a branch needed for some other reason).
+    - name: Fetch Antora playbook branches
       run: |
+        playbook_path="${DOCS_DIR}/${ANTORA_PLAYBOOK}"
+        playbook_branches=""
+        if [ -f "$playbook_path" ]; then
+          playbook_branches=$(yq eval '[.content.sources[].branches] | flatten | map(select(. != "HEAD")) | unique | join(" ")' "$playbook_path")
+        else
+          echo "::warning::Antora playbook not found at ${playbook_path}; skipping auto-detected branches"
+        fi
+
+        branches=$(printf '%s\n' $playbook_branches $ANTORA_FETCH_BRANCHES | sort -u | tr '\n' ' ')
+        if [ -z "$(echo "$branches" | tr -d '[:space:]')" ]; then
+          echo "No additional branches to fetch"
+          exit 0
+        fi
+        echo "Fetching branches: ${branches}"
+
         refspecs=()
-        for branch in $ANTORA_FETCH_BRANCHES; do
+        for branch in $branches; do
           refspecs+=("+refs/heads/${branch}:refs/remotes/origin/${branch}")
         done
         # no --depth: a shallow/grafted commit here seems to confuse antora's own

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -200,7 +200,14 @@ jobs:
           echo "::warning::Antora playbook not found at ${playbook_path}; skipping auto-detected branches"
         fi
 
-        branches=$(printf '%s\n' $playbook_branches $ANTORA_FETCH_BRANCHES | sort -u | tr '\n' ' ')
+        # Filter HEAD from the combined list too, not just the playbook-derived part -
+        # it's not a real remote branch, so a git fetch refspec for it fails outright
+        # (and fails the whole multi-refspec fetch, not just that one ref) if it ever
+        # reaches here via antora-fetch-branches instead. The `|| true` guards against
+        # grep's own exit 1 when it filters out every line (e.g. input was only "HEAD")
+        # - that's not an error, it's exactly the "nothing to fetch" case the next check
+        # handles, but bash's errexit would otherwise abort the script right here first.
+        branches=$(printf '%s\n' $playbook_branches $ANTORA_FETCH_BRANCHES | grep -v '^HEAD$' | sort -u | tr '\n' ' ' || true)
         if [ -z "$(echo "$branches" | tr -d '[:space:]')" ]; then
           echo "No additional branches to fetch"
           exit 0

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -81,10 +81,10 @@ on:
         type: string
         default: ''
       antora-playbook:
-        description: 'Antora playbook file, relative to docs-dir, to read multi-version branches from (content.sources[].branches). Every branch listed there - other than HEAD, which is whatever build-ref already checked out - is fetched automatically before the build, so this input does not need manual upkeep as versions are added or removed. Override only if a repo names its playbook something other than publish.yml.'
+        description: 'Antora playbook file, relative to docs-dir, to read multi-version branches from (content.sources[].branches). Every branch listed there - other than HEAD, which is whatever build-ref already checked out - is fetched automatically before the build, so this input does not need manual upkeep as versions are added or removed. Defaults to publish.yml for verify:publish builds and preview.yml otherwise, matching the convention every repo already follows - override only if a repo names its playbook something else.'
         required: false
         type: string
-        default: 'publish.yml'
+        default: ''
       sparse-checkout:
         description: 'Whether to sparse-checkout only docs-dir (plus sparse-checkout-extra-paths) instead of the whole repo. Only relevant when docs-dir is not ".". Set to false to check out the whole repo, e.g. if docs-dir needs to reference sibling paths elsewhere in the repo.'
         required: false
@@ -160,7 +160,7 @@ jobs:
       ANTORA_EXTENSIONS_EXCLUDE: ${{ inputs.antora-extensions-exclude }}
       ANTORA_AI_SEARCH_LINK: "${{ inputs.package-script == 'verify:publish' && '--attribute page-chatbot=https://neo4j.com/docs/assets/chatbot' || '' }}"
       ANTORA_FETCH_BRANCHES: ${{ inputs.antora-fetch-branches }}
-      ANTORA_PLAYBOOK: ${{ inputs.antora-playbook }}
+      ANTORA_PLAYBOOK: "${{ inputs.antora-playbook || (inputs.package-script == 'verify:publish' && 'publish.yml' || 'preview.yml') }}"
       SPARSE_CHECKOUT: ${{ inputs.sparse-checkout }}
       SPARSE_CHECKOUT_EXTRA_PATHS: ${{ inputs.sparse-checkout-extra-paths }}
 


### PR DESCRIPTION
## Summary
- Replace the manually-maintained `antora-fetch-branches` list with automatic detection: the branches in `content.sources[].branches` are now read directly from the Antora playbook (`antora-playbook` input, defaulting to `publish.yml` for `verify:publish` builds and `preview.yml` otherwise) and fetched with real git before the build, so nothing needs to be kept in sync by hand as versions are added or removed.
- `HEAD` is excluded, since it's Antora's keyword for "whatever's currently checked out" rather than a real branch - fetching it as a literal refspec fails outright and takes down the whole multi-refspec fetch (reproduced against the real remote).
- `antora-fetch-branches` remains as a manual escape hatch for a branch that isn't itself a playbook content source, unioned with the auto-detected list.

## Test plan
- [x] Verified the branch-extraction logic against real playbooks (flow-style arrays, block-style arrays, bare scalars, multiple `content.sources` entries) using `yq` (confirmed pre-installed on the `ubuntu-latest` runner image via GitHub's runner-images manifest)
- [x] Verified the `package-script`-based default (`preview.yml` vs `publish.yml`) resolves correctly for both cases
- [x] Verified `HEAD` is filtered from both the playbook-derived list and the final combined list (manual input included), and reproduced the real `git fetch` failure mode this avoids
- [x] Verified the `grep -v` empty-result edge case doesn't trip bash's `errexit` before reaching the graceful "nothing to fetch" path
- [x] `npm run verify:preview` in `docs/` - zero warn/error/fatal in the build log