### PR TITLE
DOCOPS-177 Strip --fetch from the package script instead of running npm run directly

### DIFF
--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -283,16 +283,12 @@ jobs:
         printf "\n\n<!---- Installed packages -->\n"
         npm list
 
-    - name: Run package script
-      id: run-package-script
+    # A missing script name is a genuine config error - not something to tolerate the way
+    # the run step's continue-on-error tolerates antora itself failing - so this step gets
+    # no continue-on-error and fails the job outright.
+    - name: Resolve package script command
+      id: resolve-command
       working-directory: ${{ env.DOCS_DIR }}
-      continue-on-error: true
-      env:
-        # antora requires local-path extensions (e.g. a sibling extensions/ dir) directly by their
-        # real filesystem path, bypassing node_modules resolution entirely. NODE_PATH gives Node an
-        # extra place to look, so those extensions can still find hoisted deps (e.g. vinyl) that are
-        # only installed under docs/node_modules.
-        NODE_PATH: ${{ github.workspace }}/${{ env.DOCS_DIR }}/node_modules
       run: |
         raw_cmd=$(node -e "process.stdout.write(require('./package.json').scripts['$PACKAGE_SCRIPT'] || '')")
         if [ -z "$raw_cmd" ]; then
@@ -308,10 +304,21 @@ jobs:
         # options-from-convict.js), so strip it from whatever the script would have run,
         # rather than editing --fetch out of every consumer's package.json by hand.
         cmd=$(echo "$raw_cmd" | sed -E 's/(^|[[:space:]])--fetch([[:space:]]|$)/\1\2/g')
+        echo "cmd=${cmd}" >> "$GITHUB_OUTPUT"
 
-        # npm run puts node_modules/.bin on PATH for the script it runs; npx resolves the
-        # locally-installed binary the same way without needing that.
-        bash -c "npx $cmd --ui-bundle-url=\"$ANTORA_UI_BUNDLE_URL\" $ANTORA_CLI_OPTIONS $ANTORA_CLI_EXTENSIONS $ANTORA_ATTRIBUTES $ANTORA_AI_SEARCH_LINK"
+    - name: Run package script
+      id: run-package-script
+      working-directory: ${{ env.DOCS_DIR }}
+      continue-on-error: true
+      env:
+        # antora requires local-path extensions (e.g. a sibling extensions/ dir) directly by their
+        # real filesystem path, bypassing node_modules resolution entirely. NODE_PATH gives Node an
+        # extra place to look, so those extensions can still find hoisted deps (e.g. vinyl) that are
+        # only installed under docs/node_modules.
+        NODE_PATH: ${{ github.workspace }}/${{ env.DOCS_DIR }}/node_modules
+      # npm run puts node_modules/.bin on PATH for the script it runs; npx resolves the
+      # locally-installed binary the same way without needing that.
+      run: npx ${{ steps.resolve-command.outputs.cmd }} --ui-bundle-url=$ANTORA_UI_BUNDLE_URL $ANTORA_CLI_OPTIONS $ANTORA_CLI_EXTENSIONS $ANTORA_ATTRIBUTES $ANTORA_AI_SEARCH_LINK
 
     - name: Print Antora log
       if: steps.run-package-script.outcome == 'failure'

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -293,7 +293,25 @@ jobs:
         # extra place to look, so those extensions can still find hoisted deps (e.g. vinyl) that are
         # only installed under docs/node_modules.
         NODE_PATH: ${{ github.workspace }}/${{ env.DOCS_DIR }}/node_modules
-      run: npm run $PACKAGE_SCRIPT -- --ui-bundle-url=$ANTORA_UI_BUNDLE_URL $ANTORA_CLI_OPTIONS $ANTORA_CLI_EXTENSIONS $ANTORA_ATTRIBUTES $ANTORA_AI_SEARCH_LINK
+      run: |
+        raw_cmd=$(node -e "process.stdout.write(require('./package.json').scripts['$PACKAGE_SCRIPT'] || '')")
+        if [ -z "$raw_cmd" ]; then
+          echo "::error::No script named '$PACKAGE_SCRIPT' in package.json"
+          exit 1
+        fi
+
+        # We've already fetched (with real git) every branch a same-repo playbook source
+        # needs, so antora's own --fetch (isomorphic-git) is unnecessary - and unreliable
+        # even when everything's already fetched (seen a NotFoundError from isomorphic-git
+        # reading a blob that real git had just fetched fine). Antora's CLI has no --no-fetch
+        # to countermand an earlier --fetch (deliberately disabled in its own source - see
+        # options-from-convict.js), so strip it from whatever the script would have run,
+        # rather than editing --fetch out of every consumer's package.json by hand.
+        cmd=$(echo "$raw_cmd" | sed -E 's/(^|[[:space:]])--fetch([[:space:]]|$)/\1\2/g')
+
+        # npm run puts node_modules/.bin on PATH for the script it runs; npx resolves the
+        # locally-installed binary the same way without needing that.
+        bash -c "npx $cmd --ui-bundle-url=\"$ANTORA_UI_BUNDLE_URL\" $ANTORA_CLI_OPTIONS $ANTORA_CLI_EXTENSIONS $ANTORA_ATTRIBUTES $ANTORA_AI_SEARCH_LINK"
 
     - name: Print Antora log
       if: steps.run-package-script.outcome == 'failure'


### PR DESCRIPTION
## Summary
- Follow-up to #108. Even after fetching a playbook's branches ourselves with real git, Antora's own `--fetch` (isomorphic-git) still ran afterward - it's baked into every consumer's `package.json` script (`"antora --stacktrace --fetch preview.yml ..."`) and runs before anything the reusable workflow appends via `npm run $PACKAGE_SCRIPT -- ...`.
- Reproduced the actual failure this caused in production (neo4j-spark-connector, [run 31406300875](https://github.com/neo4j/neo4j-spark-connector/actions/runs/31406300875/job/93513406767)): our real-git fetch of branch `4.0` succeeded, but Antora's own isomorphic-git fetch then threw `NotFoundError` trying to read a blob on that same branch moments later.
- Antora's CLI has no `--no-fetch` to countermand an earlier `--fetch` - that negation option is deliberately commented out in Antora's own source (`@antora/cli/lib/commander/options-from-convict.js`).
- Rather than editing `--fetch` out of every consumer repo's `package.json` by hand (impractical across dozens of repos), the workflow now reads the actual script command from `package.json`, strips a standalone `--fetch` from it, and runs that directly with `npx` (which resolves the local binary the same way `npm run`'s `node_modules/.bin` PATH prepending would have) instead of going through `npm run`.

## Test plan
- [x] Verified the `--fetch`-stripping regex doesn't touch similarly-named flags (e.g. `--fetching-something`)
- [x] Ran the exact extracted step end-to-end against `docs/package.json`'s `verify:preview` script - clean build, correct HTML output
- [x] Ran the exact extracted step end-to-end against `verify:publish` (the script that actually failed in production) - clean build
- [x] `npm run verify:preview` in `docs/` - zero warn/error/fatal in the build log