### PR TITLE
DOCOPS-177 Fix the actual root cause: clear the partial-clone blob filter before fetching

### DIFF
--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -229,9 +229,21 @@ jobs:
         for branch in $branches; do
           refspecs+=("+refs/heads/${branch}:refs/remotes/origin/${branch}")
         done
+
+        # fetch-depth: 0 makes actions/checkout do a blobless partial clone
+        # (--filter=blob:none) - commits and trees only, no file contents. Real git
+        # transparently lazy-fetches a missing blob on demand (e.g. from `git cat-file`),
+        # but antora's isomorphic-git has no concept of that and just fails outright -
+        # this is the actual NotFoundError root cause, not --fetch. A plain fetch here
+        # inherits that same filter from the remote config, so clear it and use
+        # --refetch to force these branches' blobs down for real, not just their commits
+        # and trees. The unsets are harmless no-ops (exit 5) when there was no partial
+        # clone filter to begin with, hence `|| true`.
+        git config --unset remote.origin.partialclonefilter 2>/dev/null || true
+        git config --unset remote.origin.promisor 2>/dev/null || true
         # no --depth: a shallow/grafted commit here seems to confuse antora's own
         # isomorphic-git fetch when it later tries to resolve these same branches
-        git fetch --no-tags origin "${refspecs[@]}"
+        git fetch --no-tags --refetch origin "${refspecs[@]}"
 
     - name: Remove excluded extensions
       run: |


### PR DESCRIPTION
## Summary
- The previous fix (#109, stripping `--fetch` from the package script) was based on a wrong theory and didn't actually work - confirmed by re-running the exact same failure in neo4j-spark-connector after that fix landed ([run 31412201505](https://github.com/neo4j/neo4j-spark-connector/actions/runs/31412201505)), same blob oid, same branch, same error.
- Real root cause: `fetch-depth: 0` makes `actions/checkout` do a blobless partial clone (`--filter=blob:none`) - it fetches commits and trees but not file contents. Real git transparently lazy-fetches a missing blob on demand over the network (which is why `git cat-file` kept succeeding while investigating - it was quietly re-fetching each time), but Antora's isomorphic-git has no concept of that and just fails outright trying to read a blob that was never actually downloaded. Our own branch-fetch step inherited the same filter from the remote's persisted config, so it never actually fixed this either - it just fetched more commits and trees, still no blobs.
- Fix: clear `remote.origin.partialclonefilter` and `remote.origin.promisor` before fetching, and add `--refetch` so the fetch forces real blob content down for these branches instead of just commits and trees.

## Test plan
- [x] Reproduced the exact failure locally: replicated `actions/checkout`'s real `--filter=blob:none` fetch against the actual neo4j-spark-connector repo, then called `isomorphic-git`'s `readBlob` directly on the same oid from the real error - got the identical `NotFoundError`
- [x] Verified the fix resolves it: same reproduction, with the config-clearing + `--refetch` fix applied - `readBlob` succeeds
- [x] Verified end-to-end with the exact step extracted from this file (not an approximation)
- [x] Verified no regression against a repo with no partial-clone filter to begin with (the unset calls are harmless no-ops there)
- [x] `npm run verify:preview` in `docs/` - zero warn/error/fatal in the build log