### PR TITLE
Set DOCS_FETCH_NAV for verify:publish builds

### DIFF
--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -161,6 +161,11 @@ jobs:
       # rather than issuing a request that's guaranteed to 404.
       ANTORA_ATTRIBUTES: "${{ inputs.antora-attributes }}${{ inputs.package-script == 'verify:publish' && ' --attribute page-chatbot=/docs/assets/chatbot --attribute page-no-local-manifest=true' || '' }}"
       ANTORA_EXTENSIONS: "${{ inputs.antora-extensions }}${{ inputs.package-script == 'verify:publish' && '@neo4j-antora/tabbed-nav' || '' }}"
+      # tabbed-nav's fetchNav defaults to false (a docset referencing it locally
+      # shouldn't silently reach out to a remote tabs.json) - publish builds need the
+      # real cross-repo aggregation, so opt in via its env-var override rather than
+      # every consumer's playbook needing to carry fetchNav: true as extension config.
+      DOCS_FETCH_NAV: "${{ inputs.package-script == 'verify:publish' && 'true' || '' }}"
       ANTORA_EXTENSIONS_EXCLUDE: ${{ inputs.antora-extensions-exclude }}
       ANTORA_AI_SEARCH_LINK: "${{ inputs.package-script == 'verify:publish' && '--attribute page-chatbot=https://neo4j.com/docs/assets/chatbot' || '' }}"
       ANTORA_FETCH_BRANCHES: ${{ inputs.antora-fetch-branches }}


### PR DESCRIPTION
## Summary
- Split out of #65 so this workflow change can merge and release independently.
- `tabbed-nav`'s `fetchNav` is switching to default off in #65, so a docset referencing the extension locally doesn't silently fetch a remote `tabs.json`. Publish builds still need the real cross-repo aggregation, so this opts in via `DOCS_FETCH_NAV` - the same env-var pattern `emitLocalManifest` already uses - rather than every consumer's playbook needing to carry `fetchNav: true` as extension config.

**Note:** this is a no-op on its own until #65 merges - `fetchNav` still defaults to `true` on `dev` right now, so setting the env var changes nothing yet. It's here so both land together without a gap where publish builds lose aggregation once #65 merges.

## Test plan
- [x] `npm run verify:preview` in `docs/` - zero warn/error/fatal in the build log