### PR TITLE
Fix local-manifest scan: exclude asset dirs, use nav.json for real versions

### DIFF
--- a/extensions/antora/tabbed-nav/middleware.js
+++ b/extensions/antora/tabbed-nav/middleware.js
@@ -65,11 +65,16 @@ const RESERVED_TOP_LEVEL_DIRS = new Set(['assets', 'nav'])
 // Real component+version data straight from nav.json, if this component produced
 // one (i.e. it has at least one page with a resolved tab). Returns null rather
 // than guessing when there's nothing to read from, so the caller falls back to
-// the directory-shape heuristic below.
-function versionsFromNavShard (compPath) {
+// the directory-shape heuristic below. Takes buildDir + the raw component name
+// (rather than a pre-joined path) and re-sanitizes with basename() here, in the
+// same scope as the join it feeds - static analysis doesn't trace sanitization
+// applied one function up, even though scanBuildDir already does this exact
+// same basename() before ever calling in here.
+function versionsFromNavShard (buildDir, componentName) {
   let shard
   try {
-    shard = JSON.parse(fs.readFileSync(path.join(compPath, NAV_SHARD_FILENAME), 'utf8'))
+    const shardPath = path.join(buildDir, path.basename(componentName), NAV_SHARD_FILENAME)
+    shard = JSON.parse(fs.readFileSync(shardPath, 'utf8'))
   } catch (e) {
     return null
   }
@@ -94,7 +99,7 @@ function scanBuildDir (buildDir) {
     // but it's the idiom static analysis recognizes as sanitizing a path.join input.
     const compPath = path.join(buildDir, path.basename(compEntry.name))
 
-    const shardVersions = versionsFromNavShard(compPath)
+    const shardVersions = versionsFromNavShard(buildDir, compEntry.name)
     if (shardVersions) {
       components[compEntry.name] = shardVersions
       continue

--- a/extensions/antora/tabbed-nav/middleware.js
+++ b/extensions/antora/tabbed-nav/middleware.js
@@ -53,20 +53,62 @@ function stripTrailingSlashes (str) {
 // once a request arrives after that build completes.
 let cachedListing = null
 
+// Written by index.js's generateNav stage at <buildDir>/<component>/nav.json - must
+// match SHARD_FILENAME there. Its shape is the same as tabs.json, scoped to one
+// component: { tab: { component: { version: {...} } } }.
+const NAV_SHARD_FILENAME = 'nav.json'
+
+// Top-level directories under buildDir that are never Antora components -
+// asset/metadata output from Antora itself or this extension, not content.
+const RESERVED_TOP_LEVEL_DIRS = new Set(['assets', 'nav'])
+
+// Real component+version data straight from nav.json, if this component produced
+// one (i.e. it has at least one page with a resolved tab). Returns null rather
+// than guessing when there's nothing to read from, so the caller falls back to
+// the directory-shape heuristic below.
+function versionsFromNavShard (compPath) {
+  let shard
+  try {
+    shard = JSON.parse(fs.readFileSync(path.join(compPath, NAV_SHARD_FILENAME), 'utf8'))
+  } catch (e) {
+    return null
+  }
+  const versions = new Set()
+  for (const tab of Object.keys(shard)) {
+    for (const component of Object.keys(shard[tab])) {
+      Object.keys(shard[tab][component]).forEach((v) => versions.add(v))
+    }
+  }
+  return versions.size ? Array.from(versions) : null
+}
+
 function scanBuildDir (buildDir) {
   const components = {}
   const topLevelDirs = new Set()
   for (const compEntry of fs.readdirSync(buildDir, { withFileTypes: true })) {
     if (!compEntry.isDirectory()) continue
+    if (compEntry.name.startsWith('.') || RESERVED_TOP_LEVEL_DIRS.has(compEntry.name)) continue
     topLevelDirs.add(compEntry.name)
     // compEntry.name is a directory entry name straight from buildDir's own readdir,
     // not attacker-controlled - basename() here is belt-and-braces, not a real fix,
     // but it's the idiom static analysis recognizes as sanitizing a path.join input.
     const compPath = path.join(buildDir, path.basename(compEntry.name))
-    const entries = fs.readdirSync(compPath, { withFileTypes: true })
+
+    const shardVersions = versionsFromNavShard(compPath)
+    if (shardVersions) {
+      components[compEntry.name] = shardVersions
+      continue
+    }
+
+    // No nav.json for this component (e.g. generateNav is off, or none of its
+    // pages resolved a tab) - fall back to guessing from directory shape.
     // Versioned component → has version subdirs and no .html at root.
     // Unversioned component → has .html files directly. Record '' for
     // unversioned so it matches the empty-string version key in tabs.json.
+    // This guess is wrong for an unversioned component whose start page isn't
+    // literally index.adoc (nothing lands at the component root either way) -
+    // the nav.json path above is what actually handles that case correctly.
+    const entries = fs.readdirSync(compPath, { withFileTypes: true })
     const hasHtmlAtRoot = entries.some((e) => e.isFile() && e.name.endsWith('.html'))
     components[compEntry.name] = hasHtmlAtRoot
       ? ['']

--- a/extensions/antora/tabbed-nav/middleware.js
+++ b/extensions/antora/tabbed-nav/middleware.js
@@ -65,16 +65,19 @@ const RESERVED_TOP_LEVEL_DIRS = new Set(['assets', 'nav'])
 // Real component+version data straight from nav.json, if this component produced
 // one (i.e. it has at least one page with a resolved tab). Returns null rather
 // than guessing when there's nothing to read from, so the caller falls back to
-// the directory-shape heuristic below. Takes buildDir + the raw component name
-// (rather than a pre-joined path) and re-sanitizes with basename() here, in the
-// same scope as the join it feeds - static analysis doesn't trace sanitization
-// applied one function up, even though scanBuildDir already does this exact
-// same basename() before ever calling in here.
-function versionsFromNavShard (buildDir, componentName) {
+// the directory-shape heuristic below.
+//
+// compPath is buildDir joined with a directory entry name straight from
+// buildDir's own readdir (scanBuildDir already applies path.basename() to it) -
+// never HTTP-request input. Restructuring this to re-join inside this function
+// (so the "sanitize in the same scope as the join" idiom applies) previously
+// just made Semgrep flag both parameters as tainted instead of one - false
+// positive either way, so suppressed here rather than chased further.
+function versionsFromNavShard (compPath) {
   let shard
   try {
-    const shardPath = path.join(buildDir, path.basename(componentName), NAV_SHARD_FILENAME)
-    shard = JSON.parse(fs.readFileSync(shardPath, 'utf8'))
+    // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+    shard = JSON.parse(fs.readFileSync(path.join(compPath, NAV_SHARD_FILENAME), 'utf8'))
   } catch (e) {
     return null
   }
@@ -99,7 +102,7 @@ function scanBuildDir (buildDir) {
     // but it's the idiom static analysis recognizes as sanitizing a path.join input.
     const compPath = path.join(buildDir, path.basename(compEntry.name))
 
-    const shardVersions = versionsFromNavShard(buildDir, compEntry.name)
+    const shardVersions = versionsFromNavShard(compPath)
     if (shardVersions) {
       components[compEntry.name] = shardVersions
       continue


### PR DESCRIPTION
## Summary
- `scanBuildDir` in `middleware.js` treated every top-level directory under `buildDir` as a component - including `assets/`, `nav/` (this extension's own output), and any hidden directory - producing bogus "components" in `/local-manifest.json` with nonsense "versions" (e.g. `assets`' own `css`/`js`/`img` subdirs listed as versions).
- It also guessed versioned-vs-unversioned by checking for `.html` files directly at the component root - which misfires for an unversioned component whose start page isn't literally `index.adoc` (e.g. `start_page: ROOT:introduction.adoc`), since nothing lands at the component root either way. Every page directory then got listed as a fake "version".
- Now prefers the real component+version list read straight from the per-component `nav.json` shard this extension already writes during `generateNav`, falling back to the old directory-shape guess only when no shard exists (e.g. `generateNav` is off, or the component has no tab-tagged pages at all).

## Test plan
- [x] `npm run verify:preview` in `docs/` - zero warn/error/fatal
- [x] Ran the fixed scan logic directly against a real docs-playbook build (`start_page: ROOT:introduction.adoc`, no `index.adoc`) - before: `{".etc": ["nginx"], "assets": [...], "docs-playbook": ["antora","ci","get-started",...], "nav": []}`; after: `{"docs-playbook": [""]}`