### PR TITLE
Merge navigation blocks before grouping, so a comment doesn't sever tab inheritance

### DIFF
--- a/extensions/antora/tabbed-nav/index.js
+++ b/extensions/antora/tabbed-nav/index.js
@@ -116,9 +116,23 @@ module.exports.register = function ({ config }) {
             // every section's landing page individually.
             const promoteAll = componentWideAttr('page-tabs-promote-all', asciidoc, playbook.asciidoc) !== undefined
 
-            for (const nav of navigation) {
+            // Antora can split one logical nav list into multiple separate
+            // "navigation" blocks - not just at module boundaries (separate nav:
+            // files), but also from a full-line comment inside a single
+            // content-nav.adoc (e.g. "// * xref:..[]"), which AsciiDoc treats as a
+            // block break, splitting what the writer sees as one continuous list
+            // into two independent ones. That severs the "top-level section + its
+            // flat sibling xrefs" relationship groupFlatNavSections depends on
+            // before this code ever sees it - a bold heading in one block never
+            // sees the xrefs that end up in the next, so they're never nested
+            // under it and never inherit its tab. Concatenating every block's
+            // items into one flat run before grouping, then putting the result
+            // back on the first block alone (emptying every other block), makes a
+            // comment-induced split behave exactly like an unbroken list.
+            navigation[0].items = groupFlatNavSections([].concat(...navigation.map((n) => n.items)))
+            for (let i = 1; i < navigation.length; i++) navigation[i].items = []
 
-              nav.items = groupFlatNavSections(nav.items)
+            for (const nav of navigation) {
 
               // Url-less leaf items (section headers, or link items Antora didn't
               // parse a url out of) awaiting backfill once a later sibling resolves

--- a/extensions/antora/tabbed-nav/package.json
+++ b/extensions/antora/tabbed-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-antora/tabbed-nav",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Antora extension, Express middleware, S3 aggregator, and turnkey dev server for tabbed cross-docset navigation across Neo4j docs repos.",
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
## Summary
Antora splits one logical nav list into separate `navigation` blocks not just at module boundaries (separate `nav:` files), but also from a full-line AsciiDoc comment inside a single `content-nav.adoc` (e.g. `// * xref:..[]`), which acts as a block break:

```
* *Work with docs*

// * xref:key-concepts.adoc[]
* xref:understand-asciidoc.adoc[]
* xref:anatomy-page.adoc[]
* xref:add-links.adoc[]
```

This silently severs the "bold heading + its flat sibling xrefs" relationship `groupFlatNavSections` depends on, before our code ever sees it - confirmed via a raw dump of Antora's own parsed `navigation` array: the heading ends up alone in one block with no children, and the three xrefs end up as an unheaded flat block of their own. So a page-tabs set on the heading's section never reaches the xrefs - they're invisible/unassigned in the aggregated nav with no obvious error.

Fix: concatenate every block's items into one flat run before grouping, then keep the grouped result on the first block alone (emptying every other block) - making a comment-induced split behave exactly like an unbroken list.

## Test plan
- [x] `npm run verify:preview` in `docs/` - zero warn/error/fatal
- [x] Reproduced with a minimal test repo matching the exact reported pattern (dumped Antora's raw `navigation` array to confirm the two-block split) - before the fix, only the page with its own explicit `page-tabs` got a tab; after, all three pages correctly nest under "Work with docs" and inherit its tab