### PR TITLE
Attach docsetGroup to flat promoted items so version selection covers them

### DIFF
--- a/extensions/antora/tabbed-nav/index.js
+++ b/extensions/antora/tabbed-nav/index.js
@@ -560,6 +560,14 @@ module.exports.register = function ({ config }) {
 
               for (const item of promotedItems) {
                 if (!(item.items && item.items.length)) {
+                  // Unlike every other branch here, this item is pushed through
+                  // unwrapped - so it also needs docsetGroup attached directly, or it
+                  // never enters the docsetGroup version-selection logic downstream
+                  // (client nav-fetch and the SSR nav-aggregate helper both skip an
+                  // item with no docsetGroup entirely) and every version's copy of a
+                  // flat promoted page (e.g. a promoteAll'd component index or
+                  // introduction page with no children) shows up simultaneously.
+                  if (versionData.docsetGroup) item.docsetGroup = versionData.docsetGroup
                   tabNav[0].items.push(item)
                   continue
                 }

--- a/extensions/antora/tabbed-nav/package.json
+++ b/extensions/antora/tabbed-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-antora/tabbed-nav",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Antora extension, Express middleware, S3 aggregator, and turnkey dev server for tabbed cross-docset navigation across Neo4j docs repos.",
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
## Summary
- A promoted top-level item with no children (a flat page — e.g. a component's own index or introduction page under `page-tabs-promote-all`) was pushed into the tab nav unwrapped, without `docsetGroup` attached the way every other item shape gets.
- Both the SSR nav-tree build (docs-ui) and the client nav-fetch rebuild skip any item lacking `docsetGroup` when picking which version of a grouped component to show, so every version's copy of that flat page rendered simultaneously.
- Confirmed live on `development.neo4j.dev`'s `operations-manual/2026.08` pages, which showed duplicate "The Neo4j Operations Manual" and "Introduction" links pointing at both `/2026.08/` and `/5/`.
- Companion fix in `docs-ui` (`09-nav-fetch.js`, `docs-restructure` branch) applies the same mirror-fix client-side.

## Test plan
- [x] Rebuilt `docs-operations`' real content with a docs-ui bundle carrying both fixes
- [x] Confirmed the SSR-rendered nav on `operations-manual/2026.08/kubernetes/` shows only the `2026.08` copies, no `5`/`4.4` duplicates
- [x] Simulated the client-side `nav-fetch` rebuild against the fixed `tabs.json` and confirmed the same result
- [x] Build log clean (zero warn/error/fatal)

Bumps `@neo4j-antora/tabbed-nav` to 0.3.6.